### PR TITLE
Clean up vertex shader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Anti-aliasing for the borders implemented.
 - Resolve linting
+- Clean up vertex shader
 
 ### Changed
 

--- a/src/layers/xr-layer/xr-layer-vertex.js
+++ b/src/layers/xr-layer/xr-layer-vertex.js
@@ -8,14 +8,7 @@ in vec3 positions64Low;
 out vec2 vTexCoord;
 
 void main() {
-
-  geometry.worldPosition = positions;
-  geometry.uv = texCoords;
-
-  gl_Position = project_position_to_clipspace(positions, positions64Low, vec3(0.0), geometry.position);
-  DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
+  gl_Position = project_position_to_clipspace(positions, positions64Low, vec3(0.0));
   vTexCoord = texCoords;
-  vec4 color = vec4(0.0);
-  DECKGL_FILTER_COLOR(color, geometry);
 }
 `;


### PR DESCRIPTION
 - `gl_Position` is the on-screen coordinates (the viewport scaled down to `[-1,1]`)
 - `vTexCoord` is one of `[[0,0],[0,1],[1,0],[1,1]]` corresponding to a coordinate system for the fragment shader to use post-rasterization (i.e rasterization chops up this unit-square into "fragments" and each fragment is processed by the fragment shader)