### PR TITLE
Fix Brightness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.0.6 - In Progress
+
+### Changed
+
+ - Fix brightness from channel toggling
+
 ## 0.0.5
 
 ### Added

--- a/src/layers/xr-layer/xr-layer-fragment.js
+++ b/src/layers/xr-layer/xr-layer-fragment.js
@@ -75,7 +75,7 @@ void main() {
 
   for(int i = 0; i < 6; i++) {
     hsvCombo = rgb2hsv(vec3(colorValues[i]));
-    hsvCombo = vec3(hsvCombo.xy, channelArray[i]);
+    hsvCombo = vec3(hsvCombo.xy, max(0.0,channelArray[i]));
     rgbCombo += hsv2rgb(hsvCombo);
   }
 


### PR DESCRIPTION
 - The ramp function is global to the shader, not to our own conversion (i.e if you tried passing in RGB values outside of the [0,1] bound or tried requesting such data from the sampler, the ramp function would kick in).  So a negative value in hsv, which is what happens when the channel is turned off, subtracts from the brightness.   Fixes #85

<img width="1423" alt="Screen Shot 2020-02-18 at 10 47 50 PM" src="https://user-images.githubusercontent.com/43999641/74800237-cf09ea80-52a0-11ea-92f6-ad0a3f80d526.png">
<img width="1412" alt="Screen Shot 2020-02-18 at 10 47 56 PM" src="https://user-images.githubusercontent.com/43999641/74800239-d03b1780-52a0-11ea-8a5a-45bf96f18193.png">
<img width="1436" alt="Screen Shot 2020-02-18 at 10 48 04 PM" src="https://user-images.githubusercontent.com/43999641/74800241-d0d3ae00-52a0-11ea-913e-af824ca9fb52.png">
