### PR TITLE
add test:watch and clean up zarr loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.1.0 - In Progress
 
+- Add `test:watch` to npm scripts.
+
 ## 0.0.9
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build-site": "mkdir dist || rm -r dist && node_modules/.bin/webpack --config webpack.config.js --mode production",
     "start": "node_modules/.bin/webpack-dev-server --mode development --open --hot",
     "test": "mkdir test_dist || rm -r test_dist && node_modules/.bin/webpack --config webpack.config.test.js --mode development",
+    "test:watch": "npm run test -- --watch",
     "version": "./version.sh",
     "postversion": "git push && git push --tags"
   },

--- a/src/loaders/zarrLoader.js
+++ b/src/loaders/zarrLoader.js
@@ -30,17 +30,11 @@ export default class ZarrLoader {
   }
 
   get _base() {
-    if (this.isPyramid) {
-      return this._data[0];
-    }
-    return this._data;
+    return this.isPyramid ? this._data[0] : this._data;
   }
 
   get vivMetadata() {
-    const data = this._data;
-    const { dtype } = Array.isArray(data)
-      ? this._data[0].meta
-      : this._data.meta;
+    const { dtype } = this._base;
     const imageHeight = this._base.shape[this.yIndex];
     const imageWidth = this._base.shape[this.xIndex];
     const tileSize = this._base.chunks[this.xIndex];


### PR DESCRIPTION
Re: #108. Tests seem to be faster now -- thanks! This PR adds `test:watch` which allows for on-save re-running of tests during development. I also cleaned up a couple lines in the loader that we had discussed in #113.