### PR TITLE
Move raster selection to loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,11 @@
 - Bump `zarr.js` to `v0.2.3`
 - Set raster selection on data loader class
 
-## 0.1.0
-
-### Changed
+### Added
 
 - Add `test:watch` to npm scripts.
 
-## 0.0.9
+## 0.1.0
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ### Changed
 
-- Update build process to use rolllup
+- Update build process to use rollup
 
 ## 0.0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## 0.1.0 - In Progress
+## 0.1.1 - In progress
+
+### Changed
+
+- Bump `zarr.js` to `v0.2.3`
+- Set raster selection on data loader class
+
+## 0.1.0
+
+### Changed
 
 - Add `test:watch` to npm scripts.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16550,13 +16550,20 @@
       }
     },
     "zarr": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.2.2.tgz",
-      "integrity": "sha512-zKk0n/HN2o/NevizSuYBgb3nrOxeWt0BV9AFt23gnpmFauTTapNeqkSBAKtMWgEtNoeWo14dg26jrJ+Y9z91DA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.2.3.tgz",
+      "integrity": "sha512-XOj81tN114prODSWFDpsQYj29RfqL7RNy0QpaB6wOb/3pABxOzI6pmxItVhSOw7baAGBgbeJweTLLTK6eGcmFA==",
       "requires": {
         "p-queue": "6.2.0",
-        "pako": "^1.0.10",
-        "ts-interface-checker": "^0.1.9"
+        "pako": "^1.0.11",
+        "ts-interface-checker": "^0.1.10"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,6 @@
   },
   "dependencies": {
     "geotiff": "^1.0.0-beta.6",
-    "zarr": "^0.2.2"
+    "zarr": "^0.2.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 import { VivViewerLayer, StaticImageLayer } from './layers';
 import VivViewer from './VivViewer';
-import { createTiffPyramid, createZarrPyramid } from './loaders';
+import { createTiffPyramid, createZarrPyramid, ZarrLoader } from './loaders';
 
 export {
   VivViewerLayer,
   VivViewer,
   StaticImageLayer,
+  ZarrLoader,
   createTiffPyramid,
   createZarrPyramid
 };

--- a/src/layers/StaticImageLayer.js
+++ b/src/layers/StaticImageLayer.js
@@ -24,8 +24,7 @@ const defaultProps = {
 };
 
 function scaleBounds({ imageWidth, imageHeight, translate, scale }) {
-  const left = translate[0];
-  const top = translate[1];
+  const [left, top] = translate;
   const right = imageWidth * scale + left;
   const bottom = imageHeight * scale + top;
   return [left, bottom, right, top];
@@ -34,7 +33,7 @@ function scaleBounds({ imageWidth, imageHeight, translate, scale }) {
 export default class StaticImageLayer extends CompositeLayer {
   initializeState() {
     const { loader } = this.props;
-    this.setState({ data: loader.getRaster({ z: 0, level: 1 }) });
+    this.setState({ data: loader.getRaster({ z: 0 }) });
   }
 
   renderLayers() {

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -13,19 +13,12 @@ export async function createZarrPyramid({
   scale,
   dimensions
 }) {
-  // Known issue with how zarr.js does string concatenation for urls
-  // The prefix gets chunked off for some reason and must be repeating in the config.
-  // https://github.com/gzuidhof/zarr.js/issues/36
-  const prefix = rootZarrUrl.split('/').slice(-1)[0];
-
   // Not necessary but this is something we should be parsing from metadata
   const maxLevel = -minZoom;
   if (maxLevel > 0) {
     const zarrStores = range(maxLevel).map(i => {
       const config = {
-        store: rootZarrUrl,
-        path: `${prefix}/${String(i).padStart(2, '0')}`,
-        mode: 'r'
+        store: `${rootZarrUrl}/${String(i).padStart(2, '0')}`
       };
       return openArray(config);
     });
@@ -33,11 +26,10 @@ export async function createZarrPyramid({
     return new ZarrLoader(connections, isRgb, scale, dimensions);
   }
   const connection = await openArray({
-    store: rootZarrUrl,
-    path: prefix,
-    mode: 'r'
+    store: rootZarrUrl
   });
-  return new ZarrLoader(connection, isRgb, scale, dimensions);
+  const loader = new ZarrLoader(connection, isRgb, scale, dimensions);
+  return loader;
 }
 
 export async function createTiffPyramid({ channelNames, channelUrls }) {

--- a/src/loaders/zarrLoader.js
+++ b/src/loaders/zarrLoader.js
@@ -25,7 +25,6 @@ export default class ZarrLoader {
     this.channelChunkSize = base.chunks[this.channelIndex];
     this.dimensions = dimensions;
     this.dimNames = Object.keys(dimensions);
-    this._selections = [Array(base.shape.length).fill(0)];
     this.type = 'zarr';
   }
 
@@ -47,41 +46,6 @@ export default class ZarrLoader {
       dtype,
       scale: this.scale
     };
-  }
-
-  setSelection(selections) {
-    const zarrSelections = [];
-    // eslint-disable-next-line no-restricted-syntax
-    for (const s of selections) {
-      const selection = Array(this._base.shape.length).fill(0);
-      // eslint-disable-next-line no-restricted-syntax
-      for (const [name, index] of s) {
-        const dimKey =
-          typeof name === 'string' ? this.dimNames.indexOf(name) : name;
-
-        if (dimKey === -1) {
-          throw Error(
-            `Dimension with name ${name} does not exist on array with dimensions : ${this.dimNames}`
-          );
-        }
-
-        const dimValue =
-          typeof index === 'string'
-            ? this.dimensions[dimKey].values.indexOf(index)
-            : index;
-
-        if (dimValue === -1) {
-          throw Error(
-            `Dimension '${this.dimNames[dimKey]}' does not contain an entry for ${index}.
-            Index must be one of ${this.dimensions[dimKey].values} or an integer.`
-          );
-        }
-
-        selection[dimKey] = dimValue;
-      }
-      zarrSelections.push(selection);
-    }
-    this._selections = zarrSelections;
   }
 
   setChunkIndex(dimName, index) {


### PR DESCRIPTION
The `level` prop was hardcoded within Viv for `getRaster`. This PR moves setting the selection to the loader instead. 