### PR TITLE
Simplify image loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fixed shaders' if-then
 - Changed UMD build name to be valid
+- Provide default args for `scale` and `isRgb` in `createZarrPyramid`.
+- Remove unneeded attributes from `TiffPyramidLoader`.
 
 ## 0.1.1
 

--- a/demo/src/initLoaders.js
+++ b/demo/src/initLoaders.js
@@ -7,8 +7,6 @@ export async function initPyramidLoader(type, { channelNames, url, minZoom }) {
       const loader = await createZarrPyramid({
         minZoom,
         rootZarrUrl: url,
-        isRgb: false,
-        scale: 1,
         dimensions: {
           channel: channelNames,
           y: null,
@@ -21,7 +19,7 @@ export async function initPyramidLoader(type, { channelNames, url, minZoom }) {
       const channelUrls = channelNames.map(
         channel => `${url}${channel}.ome.tiff`
       );
-      const loader = await createTiffPyramid({ channelNames, channelUrls });
+      const loader = await createTiffPyramid({ channelUrls });
       return loader;
     }
     case 'static': {

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -177,7 +177,7 @@ export default class XRLayer extends Layer {
         textures.channelColormap = this.dataToTexture(channelData[0]);
         this.setState({ textures });
       } else {
-        channelData.forEach(function(d, i) {
+        channelData.forEach((d, i) => {
           textures[`channel${i}`] = this.dataToTexture(d);
         }, this);
         this.setState({ textures });

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -9,9 +9,9 @@ import { range } from '../layers/VivViewerLayer/utils';
 export async function createZarrPyramid({
   rootZarrUrl,
   minZoom,
-  isRgb,
-  scale,
-  dimensions
+  dimensions,
+  isRgb = false,
+  scale = 1
 }) {
   // Not necessary but this is something we should be parsing from metadata
   const maxLevel = -minZoom;
@@ -32,7 +32,7 @@ export async function createZarrPyramid({
   return loader;
 }
 
-export async function createTiffPyramid({ channelNames, channelUrls }) {
+export async function createTiffPyramid({ channelUrls }) {
   // Open and resolve all connections asynchronously
   const tiffConnections = channelUrls.map(async url => {
     const tiff = await fromUrl(url);
@@ -45,7 +45,7 @@ export async function createTiffPyramid({ channelNames, channelUrls }) {
   });
   const pool = new Pool();
   const resolvedTiffConnections = await Promise.all(tiffConnections);
-  return new TiffPyramidLoader(resolvedTiffConnections, channelNames, pool);
+  return new TiffPyramidLoader(resolvedTiffConnections, pool);
 }
 
 export { ZarrLoader, TiffPyramidLoader };

--- a/src/loaders/tiffPyramidLoader.js
+++ b/src/loaders/tiffPyramidLoader.js
@@ -1,7 +1,6 @@
 export default class TiffPyramidLoader {
-  constructor(channelPyramids, channelNames, pool) {
+  constructor(channelPyramids, pool) {
     this.channelPyramids = channelPyramids;
-    this.channelNames = channelNames;
     this.pool = pool;
     this.type = 'tiff';
     // hardcoded for now


### PR DESCRIPTION
Some arguments for the zarr/tiff loaders are not necessary and are requiring more hardcoded logic in vitessce.