### PR TITLE
Fix and Generalize Colormap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Generalize colormaps to multichannel maps
+
 ## 0.1.3
 
 ### Added

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -16,6 +16,7 @@ const MAX_SLIDER_VALUE = 65535;
 const MIN_ZOOM = -8;
 const DEFAULT_VIEW_STATE = { zoom: -5.5, target: [30000, 10000, 0] };
 const COLORMAP = 'viridis';
+const COLORMAP_SLIDER_CHECKBOX_COLOR = [220, 220, 220];
 
 const initSourceName = 'zarr';
 const colorValues = [
@@ -26,24 +27,6 @@ const colorValues = [
   [255, 0, 255],
   [0, 255, 255]
 ];
-
-const styledSelectors = colorValues.map(value => {
-  const ColoredSlider = withStyles({
-    root: {
-      color: `rgb(${value})`
-    }
-  })(Slider);
-  const ColoredCheckbox = withStyles({
-    root: {
-      color: `rgb(${value})`,
-      '&$checked': {
-        color: `rgb(${value})`
-      }
-    },
-    checked: {}
-  })(Checkbox);
-  return [ColoredSlider, ColoredCheckbox];
-});
 
 const initSliderValues = Array(colorValues.length).fill([0, 20000]);
 const initChannelIsOn = Array(colorValues.length).fill(true);
@@ -125,23 +108,37 @@ function App() {
   });
 
   const sliders = sources[sourceName].channelNames.map((channel, i) => {
-    const [ColoredSlider, ColoredCheckbox] = styledSelectors[i];
     return (
       <div key={`container-${channel}`}>
         <p>{channel}</p>
         <div style={{ width: '100%', display: 'flex', position: 'relative' }}>
-          <ColoredCheckbox
+          <Checkbox
             onChange={() => toggleChannel(i)}
             checked={channelIsOn[i]}
+            style={{
+              color: `rgb(${
+                colormapOn ? COLORMAP_SLIDER_CHECKBOX_COLOR : colorValues[i]
+              })`,
+              '&$checked': {
+                color: `rgb(${
+                  colormapOn ? COLORMAP_SLIDER_CHECKBOX_COLOR : colorValues[i]
+                })`
+              }
+            }}
           />
-          <ColoredSlider
-            style={{ top: '7px' }}
+          <Slider
             value={sliderValues[i]}
             onChange={(event, value) => handleSliderChange(i, value)}
             valueLabelDisplay="auto"
             getAriaLabel={() => channel}
             min={MIN_SLIDER_VALUE}
             max={MAX_SLIDER_VALUE}
+            style={{
+              color: `rgb(${
+                colormapOn ? COLORMAP_SLIDER_CHECKBOX_COLOR : colorValues[i]
+              })`,
+              top: '7px'
+            }}
             orientation="horizontal"
           />
         </div>

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -47,7 +47,6 @@ const styledSelectors = colorValues.map(value => {
 
 const initSliderValues = Array(colorValues.length).fill([0, 20000]);
 const initChannelIsOn = Array(colorValues.length).fill(true);
-const initColormaps = Array(colorValues.length).fill('');
 function App() {
   const [sliderValues, setSliderValues] = useState(initSliderValues);
   const [channelIsOn, setChannelIsOn] = useState(initChannelIsOn);

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -15,6 +15,7 @@ const MIN_SLIDER_VALUE = 0;
 const MAX_SLIDER_VALUE = 65535;
 const MIN_ZOOM = -8;
 const DEFAULT_VIEW_STATE = { zoom: -5.5, target: [30000, 10000, 0] };
+const COLORMAP = 'viridis';
 
 const initSourceName = 'zarr';
 const colorValues = [
@@ -25,6 +26,7 @@ const colorValues = [
   [255, 0, 255],
   [0, 255, 255]
 ];
+
 const styledSelectors = colorValues.map(value => {
   const ColoredSlider = withStyles({
     root: {
@@ -45,7 +47,7 @@ const styledSelectors = colorValues.map(value => {
 
 const initSliderValues = Array(colorValues.length).fill([0, 20000]);
 const initChannelIsOn = Array(colorValues.length).fill(true);
-
+const initColormaps = Array(colorValues.length).fill('');
 function App() {
   const [sliderValues, setSliderValues] = useState(initSliderValues);
   const [channelIsOn, setChannelIsOn] = useState(initChannelIsOn);
@@ -53,6 +55,7 @@ function App() {
   const [viewWidth, setViewWidth] = useState(window.innerWidth * 0.7);
   const [viewHeight, setViewHeight] = useState(window.innerHeight * 0.9);
   const [loader, setLoader] = useState(null);
+  const [colormapOn, setColormap] = useState('');
 
   useEffect(() => {
     const handleResize = () => {
@@ -98,6 +101,13 @@ function App() {
       return nextChannelsOn;
     });
   };
+
+  const toggleColormap = () => {
+    setColormap(prevColormap => {
+      return prevColormap ? '' : COLORMAP;
+    });
+  };
+
   const sourceButtons = Object.keys(sources).map(name => {
     return (
       // only use isPublic on the deployment
@@ -117,10 +127,20 @@ function App() {
 
   const sliders = sources[sourceName].channelNames.map((channel, i) => {
     const [ColoredSlider, ColoredCheckbox] = styledSelectors[i];
+    const ColorMap = (
+      <Button
+        variant="contained"
+        onClick={() => toggleColormap()}
+        key="colormap"
+      >
+        {COLORMAP}
+      </Button>
+    );
     return (
       <div key={`container-${channel}`}>
         <p>{channel}</p>
         <div style={{ width: '100%', display: 'flex', position: 'relative' }}>
+          {i === 0 ? ColorMap : []}
           <ColoredCheckbox
             onChange={() => toggleChannel(i)}
             checked={channelIsOn[i]}
@@ -163,7 +183,7 @@ function App() {
             sources[initSourceName].channelNames.length
           )}
           initialViewState={initialViewState}
-          colormap={sourceName === 'static' ? 'viridis' : ''}
+          colormap={colormapOn}
         />
       ) : null}
       <div className="slider-container">

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -127,20 +127,10 @@ function App() {
 
   const sliders = sources[sourceName].channelNames.map((channel, i) => {
     const [ColoredSlider, ColoredCheckbox] = styledSelectors[i];
-    const ColorMap = (
-      <Button
-        variant="contained"
-        onClick={() => toggleColormap()}
-        key="colormap"
-      >
-        {COLORMAP}
-      </Button>
-    );
     return (
       <div key={`container-${channel}`}>
         <p>{channel}</p>
         <div style={{ width: '100%', display: 'flex', position: 'relative' }}>
-          {i === 0 ? ColorMap : []}
           <ColoredCheckbox
             onChange={() => toggleChannel(i)}
             checked={channelIsOn[i]}
@@ -205,6 +195,14 @@ function App() {
         <ButtonGroup color="primary" size="small">
           {sourceButtons}
         </ButtonGroup>
+        <br />
+        <Button
+          variant="contained"
+          onClick={() => toggleColormap()}
+          key="colormap"
+        >
+          {COLORMAP}
+        </Button>
         {sliders}
       </div>
     </div>

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -1,11 +1,5 @@
 import React, { useState, useEffect, memo } from 'react';
-import {
-  Button,
-  ButtonGroup,
-  Slider,
-  Checkbox,
-  withStyles
-} from '@material-ui/core';
+import { Button, ButtonGroup, Slider, Checkbox } from '@material-ui/core';
 import { VivViewer } from '../../src';
 import { initPyramidLoader } from './initLoaders';
 import sources from './source-info';

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -194,7 +194,7 @@ function App() {
         <ButtonGroup color="primary" size="small">
           {sourceButtons}
         </ButtonGroup>
-        <div style={{ 'margin-top': '15px', 'margin-bottom': '15px' }}>
+        <div style={{ marginTop: '15px', marginBottom: '15px' }}>
           <Button
             variant="contained"
             onClick={() => toggleColormap()}

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -195,14 +195,15 @@ function App() {
         <ButtonGroup color="primary" size="small">
           {sourceButtons}
         </ButtonGroup>
-        <br />
-        <Button
-          variant="contained"
-          onClick={() => toggleColormap()}
-          key="colormap"
-        >
-          {COLORMAP}
-        </Button>
+        <div style={{ 'margin-top': '15px', 'margin-bottom': '15px' }}>
+          <Button
+            variant="contained"
+            onClick={() => toggleColormap()}
+            key="colormap"
+          >
+            {colormapOn ? 'Colors' : COLORMAP}
+          </Button>
+        </div>
         {sliders}
       </div>
     </div>

--- a/src/layers/StaticImageLayer.js
+++ b/src/layers/StaticImageLayer.js
@@ -73,11 +73,9 @@ export default class StaticImageLayer extends CompositeLayer {
       // have multiple data slices loaded and
       // simply change the index to get different views.
       // https://github.com/hubmapconsortium/vitessce-image-viewer/issues/109
-      sliderValues: colormap
-        ? paddedSliderValues.slice(0, 2)
-        : paddedSliderValues,
+      sliderValues: paddedSliderValues,
       // no need for color in the case of a provided colormap
-      colorValues: colormap ? [] : paddedColorValues,
+      colorValues: paddedColorValues,
       staticImageHeight: imageHeight,
       staticImageWidth: imageWidth,
       id: `XR-Static-Layer-${0}-${imageHeight}-${imageWidth}-${0}`,

--- a/src/layers/StaticImageLayer.js
+++ b/src/layers/StaticImageLayer.js
@@ -68,13 +68,11 @@ export default class StaticImageLayer extends CompositeLayer {
       channelData: data,
       data: null,
       bounds,
-      // Colormaps should only use one sliderValue pair.
       // Going forward, we should have more intricate indexing so we can
       // have multiple data slices loaded and
-      // simply change the index to get different views.
+      // simply change the index to get different views with colormaps, potentially.
       // https://github.com/hubmapconsortium/vitessce-image-viewer/issues/109
       sliderValues: paddedSliderValues,
-      // no need for color in the case of a provided colormap
       colorValues: paddedColorValues,
       staticImageHeight: imageHeight,
       staticImageWidth: imageWidth,

--- a/src/layers/VivViewerLayer/utils.js
+++ b/src/layers/VivViewerLayer/utils.js
@@ -60,8 +60,8 @@ export function renderSubLayers(props) {
         data: null,
         channelData: data,
         // See StaticImageLayer for why this is here.
-        sliderValues: colormap ? sliderValues.slice(0, 2) : sliderValues,
-        colorValues: colormap ? [] : colorValues,
+        sliderValues,
+        colorValues,
         tileSize,
         bounds: [left, bottom, right, top],
         opacity,

--- a/src/layers/VivViewerLayer/utils.js
+++ b/src/layers/VivViewerLayer/utils.js
@@ -59,7 +59,6 @@ export function renderSubLayers(props) {
         id: `XRLayer-left${left}-top${top}-right${right}-bottom${bottom}`,
         data: null,
         channelData: data,
-        // See StaticImageLayer for why this is here.
         sliderValues,
         colorValues,
         tileSize,

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -146,26 +146,12 @@ export default class XRLayer extends Layer {
   draw({ uniforms }) {
     const { textures, model } = this.state;
     if (textures && model) {
-      const { sliderValues, colorValues, opacity, dtype } = this.props;
-      // To prevent an overload of colors in the color map, we divide the intesities
-      // by the number that are turned on (i.e those with a slider range that is not
-      // [max,max])
-      const divisor = sliderValues.reduce(
-        // eslint-disable-next-line no-unused-vars
-        (total, currentValue, currentIndex, arr) => {
-          return DTYPE_VALUES[dtype].max !== currentValue &&
-            currentIndex % 2 === 0
-            ? total + 1
-            : total + 0;
-        },
-        0
-      );
+      const { sliderValues, colorValues, opacity } = this.props;
       model
         .setUniforms({
           ...uniforms,
           colorValues,
           sliderValues,
-          divisor,
           opacity,
           ...textures
         })

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -68,7 +68,7 @@ export default class XRLayer extends Layer {
 
   updateState({ props, oldProps, changeFlags }) {
     // setup model first
-    if (changeFlags.extensionsChanged) {
+    if (changeFlags.extensionsChanged || props.colormap !== oldProps.colormap) {
       const { gl } = this.context;
       if (this.state.model) {
         this.state.model.delete();
@@ -172,16 +172,11 @@ export default class XRLayer extends Layer {
       Object.values(this.state.textures).forEach(tex => tex && tex.delete());
     }
     if (channelData.length > 0) {
-      if (this.props.colormap) {
-        // assume first dimension is the one we want to fetch
-        textures.channelColormap = this.dataToTexture(channelData[0]);
-        this.setState({ textures });
-      } else {
-        channelData.forEach((d, i) => {
-          textures[`channel${i}`] = this.dataToTexture(d);
-        }, this);
-        this.setState({ textures });
-      }
+      textures.channelColormap = this.dataToTexture(channelData[0]);
+      channelData.forEach((d, i) => {
+        textures[`channel${i}`] = this.dataToTexture(d);
+      }, this);
+      this.setState({ textures });
     }
   }
 

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -148,6 +148,7 @@ export default class XRLayer extends Layer {
     if (textures && model) {
       const { sliderValues, colorValues, opacity, dtype } = this.props;
       const divisor = sliderValues.reduce(
+        // eslint-disable-next-line no-unused-vars
         (total, currentValue, currentIndex, arr) => {
           return DTYPE_VALUES[dtype].max !== currentValue &&
             currentIndex % 2 === 0

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -147,6 +147,9 @@ export default class XRLayer extends Layer {
     const { textures, model } = this.state;
     if (textures && model) {
       const { sliderValues, colorValues, opacity, dtype } = this.props;
+      // To prevent an overload of colors in the color map, we divide the intesities
+      // by the number that are turned on (i.e those with a slider range that is not
+      // [max,max])
       const divisor = sliderValues.reduce(
         // eslint-disable-next-line no-unused-vars
         (total, currentValue, currentIndex, arr) => {

--- a/src/layers/XRLayer/xr-layer-fragment-colormap.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment-colormap.glsl
@@ -80,9 +80,9 @@ void main() {
   float intensityValue5 = (float(texture(channel5, vTexCoord).r) - sliderValues[5][0]) / sliderValues[5][1];
 
   float intensityArray[6] = float[6](intensityValue0, intensityValue1, intensityValue2, intensityValue3, intensityValue4, intensityValue5);
-  vec4 colorCombo = vec4(0.0);
+  float intensityCombo = 0.0;
   for(int i = 0; i < 6; i++) {
-    colorCombo += colormapFunction(min(1.0,intensityArray[i] / divisor));
+    intensityCombo += max(0.0,intensityArray[i]);
   }
-  color = vec4(colorCombo.xyz, opacity);
+  color = vec4(colormapFunction(min(1.0,intensityCombo)).xyz, opacity);
 }

--- a/src/layers/XRLayer/xr-layer-fragment-colormap.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment-colormap.glsl
@@ -3,6 +3,7 @@
 precision highp float;
 precision highp int;
 precision highp usampler2D;
+
 #pragma glslify: jet = require("glsl-colormap/jet")
 #pragma glslify: hsv = require("glsl-colormap/hsv")
 #pragma glslify: hot = require("glsl-colormap/hot")
@@ -50,13 +51,19 @@ precision highp usampler2D;
 
 
 // our texture
-uniform usampler2D channelColormap;
+uniform usampler2D channel0;
+uniform usampler2D channel1;
+uniform usampler2D channel2;
+uniform usampler2D channel3;
+uniform usampler2D channel4;
+uniform usampler2D channel5;
 
 // range
-uniform vec2 sliderValues;
+uniform vec2 sliderValues[6];
 
 // opacity
 uniform float opacity;
+uniform float divisor;
 
 in vec2 vTexCoord;
 
@@ -65,7 +72,17 @@ out vec4 color;
 
 
 void main() {
-  float intensityValue = (float(texture(channelColormap, vTexCoord).r) - sliderValues[0]) / sliderValues[1];
+  float intensityValue0 = (float(texture(channel0, vTexCoord).r) - sliderValues[0][0]) / sliderValues[0][1];
+  float intensityValue1 = (float(texture(channel1, vTexCoord).r) - sliderValues[1][0]) / sliderValues[1][1];
+  float intensityValue2 = (float(texture(channel2, vTexCoord).r) - sliderValues[2][0]) / sliderValues[2][1];
+  float intensityValue3 = (float(texture(channel3, vTexCoord).r) - sliderValues[3][0]) / sliderValues[3][1];
+  float intensityValue4 = (float(texture(channel4, vTexCoord).r) - sliderValues[4][0]) / sliderValues[4][1];
+  float intensityValue5 = (float(texture(channel5, vTexCoord).r) - sliderValues[5][0]) / sliderValues[5][1];
 
-  color = vec4(colormap(min(1.0,intensityValue)).xyz, opacity);
+  float intensityArray[6] = float[6](intensityValue0, intensityValue1, intensityValue2, intensityValue3, intensityValue4, intensityValue5);
+  vec4 colorCombo = vec4(0.0);
+  for(int i = 0; i < 6; i++) {
+    colorCombo += colormapFunction(min(1.0,intensityArray[i] / divisor));
+  }
+  color = vec4(colorCombo.xyz, opacity);
 }


### PR DESCRIPTION
 - Fixes  #127
 - Generalizes to allow for multi-channnel, single colormap

The second point I would like some input on.  When I first did this, I figured only one channel at a time would be fine but making that [small change](https://github.com/hubmapconsortium/vitessce-image-viewer/compare/master...ilan-gold/fix_colormap#diff-7521b7078eea189519ea0dc27ea4fae1R71) to fix the fact that `draw` was not being called broke a lot of stuff so I figured I'd give this an overhaul.  Do we want to support multiple colormaps at once?  If so, I could do that, probably.