### PR TITLE
Add Background image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Add background image for nicer loading and temp fix for minZoom issue
+
 ### Changed
 
 - Generalize colormaps to multichannel maps

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ small non-pyramidal, i.e that are not tiled.
 
 ##### `loader` (Object)
 
-A `loader` is the primary object responsible for returning tile data as well as the required metadata for Viv. We allow loaders to be generic so viv can be used with various sources. A laoader must implement a `getTile` method and have the property `vivMetadata`. We provide the `createZarrPyramid` and `createTiffPyramid` to which are convenience functions for creating instances of valid loaders for these data types.
+A `loader` is the primary object responsible for returning tile data as well as the required metadata for Viv. We allow loaders to be generic so viv can be used with various sources. A loader must implement a `getTile` method as well as a `getRaster` method and have the property `vivMetadata`. We provide the `createZarrPyramid` and `createTiffPyramid` to which are convenience functions for creating instances of valid loaders for these data types. Those contained in this repo are experimental and subject to change with a stronger formalization being developed [here](https://github.com/hubmapconsortium/vitessce-image-loader)
 
 ###### `loader.getTile` (Function, VivViewerLayer) **POTENTIAL FUTURE BREAKING CHANGES WITH NEW FEATURES**
 
@@ -86,8 +86,7 @@ This function returns the entire image from the loader's source.
 
 Receives arguments:
 
-- `z` (optional) The z coordinate of the pyramid form which data should be fetched.
-- `level` (optional) The location along a third channel dimension along which data should be fetched.
+- `z` (optional) The z coordinate of the pyramid form which data should be fetched, if needed.
 
 ###### `loader.vivMetadata` (Object)
 

--- a/src/layers/StaticImageLayer.js
+++ b/src/layers/StaticImageLayer.js
@@ -33,7 +33,8 @@ function scaleBounds({ imageWidth, imageHeight, translate, scale }) {
 export default class StaticImageLayer extends CompositeLayer {
   initializeState() {
     const { loader } = this.props;
-    this.setState({ data: loader.getRaster() });
+    const { minZoom } = loader.vivMetadata;
+    this.setState({ data: loader.getRaster({ z: -minZoom - 1 }) });
   }
 
   renderLayers() {

--- a/src/layers/StaticImageLayer.js
+++ b/src/layers/StaticImageLayer.js
@@ -33,7 +33,7 @@ function scaleBounds({ imageWidth, imageHeight, translate, scale }) {
 export default class StaticImageLayer extends CompositeLayer {
   initializeState() {
     const { loader } = this.props;
-    this.setState({ data: loader.getRaster({ z: 0 }) });
+    this.setState({ data: loader.getRaster() });
   }
 
   renderLayers() {
@@ -49,7 +49,10 @@ export default class StaticImageLayer extends CompositeLayer {
       scale,
       domain
     } = this.props;
-    const { imageWidth, imageHeight, dtype } = loader.vivMetadata;
+    const { dtype } = loader.vivMetadata;
+    const imageHeight =
+      this.props.imageHeight || loader.vivMetadata.imageHeight;
+    const imageWidth = this.props.imageWidth || loader.vivMetadata.imageWidth;
     const { paddedSliderValues, paddedColorValues } = padColorsAndSliders({
       sliderValues,
       colorValues,

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -76,8 +76,9 @@ export default class VivViewerLayer extends CompositeLayer {
       }
     });
     // This gives us a background image and also solves the current
-    // minZoom funny business.  We don't use it for backgruond if we have an opacity
-    // paramteter set to anything but 1, but we always use it for minZoom situations.
+    // minZoom funny business.  We don't use it for the background if we have an opacity
+    // paramteter set to anything but 1, but we always use it for situations where
+    // we are zoomed out too far.
     const baseLayer = new StaticImageLayer(this.props, {
       id: `StaticImageLayer-${loader.type}`,
       scale: 2 ** (-minZoom - 1),

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -69,6 +69,9 @@ export default class VivViewerLayer extends CompositeLayer {
       sliderValues: paddedSliderValues,
       refinementStrategy: opacity === 1 ? 'best-available' : 'never'
     });
+    // This gives us a background image and also solves the current
+    // minZoom funny business.  We don't use it for backgruond if we have an opacity
+    // paramteter set to anything but 1, but we always use it for minZoom situations.
     const baseLayer = new StaticImageLayer(this.props, {
       id: `StaticImageLayer-${loader.type}`,
       scale: 2 ** (-minZoom - 1),

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -19,7 +19,8 @@ export default class VivViewerLayer extends CompositeLayer {
       sliderValues,
       colorValues,
       channelIsOn,
-      domain
+      domain,
+      opacity
     } = this.props;
     const {
       imageWidth,
@@ -44,7 +45,8 @@ export default class VivViewerLayer extends CompositeLayer {
           imageWidth,
           imageHeight,
           minZoom,
-          tileSize
+          tileSize,
+          opacity
         })
       ) {
         return loader.getTile({
@@ -55,25 +57,26 @@ export default class VivViewerLayer extends CompositeLayer {
       }
       return null;
     };
-    const layers = [
-      new StaticImageLayer(this.props, {
-        id: `StaticImageLayer-${loader.type}`,
-        scale: 2 ** (-minZoom - 1),
-        imageHeight: tileSize,
-        imageWidth: tileSize
-      }),
-      new VivViewerLayerBase(this.props, {
-        id: `VivViewerLayerBase--${loader.type}`,
-        imageWidth,
-        imageHeight,
-        tileSize,
-        minZoom,
-        getTileData,
-        dtype,
-        colorValues: paddedColorValues,
-        sliderValues: paddedSliderValues
-      })
-    ];
+    const tiledLayer = new VivViewerLayerBase(this.props, {
+      id: `VivViewerLayerBase--${loader.type}`,
+      imageWidth,
+      imageHeight,
+      tileSize,
+      minZoom,
+      getTileData,
+      dtype,
+      colorValues: paddedColorValues,
+      sliderValues: paddedSliderValues,
+      refinementStrategy: opacity === 1 ? 'best-available' : 'never'
+    });
+    const baseLayer = new StaticImageLayer(this.props, {
+      id: `StaticImageLayer-${loader.type}`,
+      scale: 2 ** (-minZoom - 1),
+      imageHeight: tileSize,
+      imageWidth: tileSize,
+      visible: opacity === 1 || minZoom > this.context.viewport.zoom
+    });
+    const layers = [baseLayer, tiledLayer];
     return layers;
   }
 }

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -4,7 +4,6 @@ import VivViewerLayerBase from './VivViewerLayerBase';
 import StaticImageLayer from '../StaticImageLayer';
 import { isInTileBounds } from './utils';
 import { padColorsAndSliders } from '../utils';
-import { ZarrLoader } from '../../loaders';
 
 export default class VivViewerLayer extends CompositeLayer {
   // see https://github.com/uber/deck.gl/blob/master/docs/api-reference/layer.md#shouldupdatestate
@@ -67,7 +66,9 @@ export default class VivViewerLayer extends CompositeLayer {
       dtype,
       colorValues: paddedColorValues,
       sliderValues: paddedSliderValues,
-      refinementStrategy: opacity === 1 ? 'best-available' : 'never',
+      // We want a no-overlap caching strategy with an opacity < 1 to prevent
+      // multiple rendered sublayers (some of which have been cached) from overlapping
+      refinementStrategy: opacity === 1 ? 'best-available' : 'no-overlap',
       // TileLayer checks `changeFlags.updateTriggersChanged.getTileData` to see if tile cache
       // needs to be re-created. We want to trigger this behavior if the loader changes.
       // https://github.com/uber/deck.gl/blob/3f67ea6dfd09a4d74122f93903cb6b819dd88d52/modules/geo-layers/src/tile-layer/tile-layer.js#L50

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -1,8 +1,10 @@
 import { CompositeLayer } from '@deck.gl/core';
 // eslint-disable-next-line import/extensions
 import VivViewerLayerBase from './VivViewerLayerBase';
+import StaticImageLayer from '../StaticImageLayer';
 import { isInTileBounds } from './utils';
 import { padColorsAndSliders } from '../utils';
+import { ZarrLoader } from '../../loaders';
 
 export default class VivViewerLayer extends CompositeLayer {
   // see https://github.com/uber/deck.gl/blob/master/docs/api-reference/layer.md#shouldupdatestate
@@ -53,17 +55,25 @@ export default class VivViewerLayer extends CompositeLayer {
       }
       return null;
     };
-    const layers = new VivViewerLayerBase(this.props, {
-      id: `VivViewerLayerBase--${loader.type}`,
-      imageWidth,
-      imageHeight,
-      tileSize,
-      minZoom,
-      getTileData,
-      dtype,
-      colorValues: paddedColorValues,
-      sliderValues: paddedSliderValues
-    });
+    const layers = [
+      new StaticImageLayer(this.props, {
+        id: `StaticImageLayer-${loader.type}`,
+        scale: 2 ** (-minZoom - 1),
+        imageHeight: tileSize,
+        imageWidth: tileSize
+      }),
+      new VivViewerLayerBase(this.props, {
+        id: `VivViewerLayerBase--${loader.type}`,
+        imageWidth,
+        imageHeight,
+        tileSize,
+        minZoom,
+        getTileData,
+        dtype,
+        colorValues: paddedColorValues,
+        sliderValues: paddedSliderValues
+      })
+    ];
     return layers;
   }
 }

--- a/src/loaders/zarrLoader.js
+++ b/src/loaders/zarrLoader.js
@@ -88,14 +88,16 @@ export default class ZarrLoader {
     return [data];
   }
 
-  async getRaster() {
-    const source = this.isPyramid
-      ? this._data[this._data.length - 1]
-      : this._data;
+  async getRaster({ z }) {
+    const source = this.isPyramid ? this._data[z] : this._data;
     const selection = [...this.chunkIndex];
     selection[this.xIndex] = null;
     selection[this.yIndex] = null;
+    selection[this.channelIndex] = null;
     const { data } = await source.getRaw(selection);
+    if (this.channelChunkSize > 1) {
+      return this._decodeChannels(data);
+    }
     return [data];
   }
 

--- a/src/loaders/zarrLoader.js
+++ b/src/loaders/zarrLoader.js
@@ -88,8 +88,10 @@ export default class ZarrLoader {
     return [data];
   }
 
-  async getRaster({ z }) {
-    const source = this.isPyramid ? this._data[z] : this._data;
+  async getRaster() {
+    const source = this.isPyramid
+      ? this._data[this._data.length - 1]
+      : this._data;
     const selection = [...this.chunkIndex];
     selection[this.xIndex] = null;
     selection[this.yIndex] = null;


### PR DESCRIPTION
This fixes #68 addressing two problems at once:
 - There is currently an issue where zooming out too far leaves the viewer without an image
 - Zooming and panning previously could cause the user to see black splotches of unloaded regions, but no longer.