### PR TITLE
minZoom refactor & force loaders to implement `onTileError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 
 ### Changed
 
-- Generalize colormaps to multichannel maps
+- Generalize colormaps to multichannel maps.
 - Add flags to check for loader change and rerender.
+- Remove minZoom from loaders and make loaders provide `onTileError`.
 
 ## 0.1.3
 

--- a/src/layers/StaticImageLayer.js
+++ b/src/layers/StaticImageLayer.js
@@ -16,8 +16,7 @@ const defaultProps = {
   loader: {
     type: 'object',
     value: {
-      getRaster: () => [],
-      getRasterSize: () => ({ imageWidth: 0, imageHeight: 0 }),
+      getRaster: async () => ({ data: [], height: 0, width: 0 }),
       dtype: '<u2'
     },
     compare: true
@@ -25,19 +24,18 @@ const defaultProps = {
   z: { type: 'number', value: 0, compare: true }
 };
 
-function scaleBounds({ imageWidth, imageHeight, translate, scale }) {
+function scaleBounds({ width, height, translate, scale }) {
   const [left, top] = translate;
-  const right = imageWidth * scale + left;
-  const bottom = imageHeight * scale + top;
+  const right = width * scale + left;
+  const bottom = height * scale + top;
   return [left, bottom, right, top];
 }
 
 export default class StaticImageLayer extends CompositeLayer {
   initializeState() {
     const { loader, z } = this.props;
-    this.setState({
-      data: loader.getRaster({ z }),
-      z
+    loader.getRaster({ z }).then(({ data, width, height }) => {
+      this.setState({ data, width, height });
     });
   }
 
@@ -49,7 +47,9 @@ export default class StaticImageLayer extends CompositeLayer {
     ) {
       // Only fetch new data to render if loader has changed
       const { loader, z } = this.props;
-      this.setState({ data: loader.getRaster({ z }) });
+      loader.getRaster({ z }).then(({ data, width, height }) => {
+        this.setState({ data, width, height });
+      });
     }
   }
 
@@ -64,8 +64,7 @@ export default class StaticImageLayer extends CompositeLayer {
       channelIsOn,
       translate,
       scale,
-      domain,
-      z
+      domain
     } = this.props;
 
     const { dtype } = loader;
@@ -77,24 +76,26 @@ export default class StaticImageLayer extends CompositeLayer {
       dtype
     });
 
-    const { data } = this.state;
-    const { imageWidth, imageHeight } = loader.getRasterSize({ z });
+    const { data, width, height } = this.state;
     const bounds = scaleBounds({
-      imageWidth,
-      imageHeight,
+      width,
+      height,
       translate,
       scale
     });
+
+    if (!(data && width && height)) return null;
+
     return new XRLayer({
       channelData: data,
       bounds,
       sliderValues: paddedSliderValues,
       colorValues: paddedColorValues,
-      height: imageHeight,
-      width: imageWidth,
-      id: `XR-Static-Layer-${0}-${imageHeight}-${imageWidth}-${0}`,
+      id: `XR-Static-Layer-${0}-${width}-${height}-${0}`,
       pickable: false,
       coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+      width,
+      height,
       opacity,
       visible,
       dtype,

--- a/src/layers/StaticImageLayer.js
+++ b/src/layers/StaticImageLayer.js
@@ -17,7 +17,8 @@ const defaultProps = {
     type: 'object',
     value: {
       getRaster: () => [],
-      vivMetadata: { imageHeight: 0, imageWidth: 0, dtype: '<u2' }
+      getRasterSize: () => ({ imageWidth: 0, imageHeight: 0 }),
+      dtype: '<u2'
     },
     compare: true
   },

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -18,7 +18,8 @@ export default class VivViewerLayer extends CompositeLayer {
       colorValues,
       channelIsOn,
       domain,
-      opacity
+      opacity,
+      onTileError
     } = this.props;
     const { tileSize, numLevels, dtype } = loader;
     const { paddedSliderValues, paddedColorValues } = padColorsAndSliders({
@@ -52,7 +53,7 @@ export default class VivViewerLayer extends CompositeLayer {
       updateTriggers: {
         getTileData: [loader]
       },
-      onTileError: loader.onTileError
+      onTileError: onTileError || loader.onTileError
     });
     // This gives us a background image and also solves the current
     // minZoom funny business.  We don't use it for the background if we have an opacity

--- a/src/layers/VivViewerLayer/VivViewerLayerBase.js
+++ b/src/layers/VivViewerLayer/VivViewerLayerBase.js
@@ -9,8 +9,6 @@ const defaultProps = {
   sliderValues: { type: 'array', value: [], compare: true },
   colorValues: { type: 'array', value: [], compare: true },
   tileSize: { type: 'number', value: 512, compare: true },
-  imageHeight: { type: 'number', value: 1028, compare: true },
-  imageWidth: { type: 'number', value: 1028, compare: true },
   minZoom: { type: 'number', value: 0, compare: true },
   maxZoom: { type: 'number', value: 0, compare: true },
   renderSubLayers: { type: 'function', value: renderSubLayers, compare: false },

--- a/src/layers/VivViewerLayer/utils.js
+++ b/src/layers/VivViewerLayer/utils.js
@@ -4,71 +4,38 @@ export function range(len) {
   return [...Array(len).keys()];
 }
 
-export function isInTileBounds({
-  x,
-  y,
-  z,
-  imageWidth,
-  imageHeight,
-  tileSize,
-  minZoom
-}) {
-  const xInBounds = x < Math.ceil(imageWidth / (tileSize * 2 ** z)) && x >= 0;
-  const yInBounds = y < Math.ceil(imageHeight / (tileSize * 2 ** z)) && y >= 0;
-  const zInBounds = z >= 0 && z < -minZoom;
-  return xInBounds && yInBounds && zInBounds;
-}
-
 export function renderSubLayers(props) {
   const {
-    bbox: { left, top, right, bottom },
-    x,
-    y,
-    z
-    // eslint-disable-next-line react/destructuring-assignment
+    bbox: { left, top, right, bottom }
   } = props.tile;
+
   const {
     colorValues,
     sliderValues,
-    imageWidth,
-    imageHeight,
     tileSize,
-    minZoom,
     visible,
     opacity,
     data,
     colormap,
     dtype
   } = props;
-  if (
-    isInTileBounds({
-      x,
-      y,
-      z: -z,
-      imageWidth,
-      imageHeight,
-      tileSize,
-      minZoom
-    })
-  ) {
-    const xrl =
-      // If image metadata is undefined, do not render this layer.
-      imageWidth &&
-      imageHeight &&
-      new XRLayer({
-        id: `XRLayer-left${left}-top${top}-right${right}-bottom${bottom}`,
-        data: null,
-        channelData: data,
-        sliderValues,
-        colorValues,
-        tileSize,
-        bounds: [left, bottom, right, top],
-        opacity,
-        visible,
-        dtype,
-        colormap
-      });
-    return xrl;
+
+  // Only render in positive coorinate system
+  if ([left, top, right, bottom].some(v => v < 0)) {
+    return null;
   }
-  return null;
+
+  return new XRLayer({
+    id: `XRLayer-left${left}-top${top}-right${right}-bottom${bottom}`,
+    bounds: [left, bottom, right, top],
+    width: tileSize,
+    height: tileSize,
+    channelData: data,
+    sliderValues,
+    colorValues,
+    opacity,
+    visible,
+    dtype,
+    colormap
+  });
 }

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -180,11 +180,11 @@ export default class XRLayer extends Layer {
   }
 
   dataToTexture(data) {
-    const { dtype } = this.props;
+    const { dtype, width, height } = this.props;
     const { format, dataFormat, type } = DTYPE_VALUES[dtype];
     const texture = new Texture2D(this.context.gl, {
-      width: this.props.staticImageWidth || this.props.tileSize,
-      height: this.props.staticImageHeight || this.props.tileSize,
+      width,
+      height,
       data,
       // we don't want or need mimaps
       mipmaps: false,

--- a/src/loaders/tiffPyramidLoader.js
+++ b/src/loaders/tiffPyramidLoader.js
@@ -1,3 +1,5 @@
+import { isInTileBounds } from './utils';
+
 export default class TiffPyramidLoader {
   constructor(channelPyramids, pool) {
     this.channelPyramids = channelPyramids;
@@ -83,15 +85,17 @@ export default class TiffPyramidLoader {
 
   _tileInBounds({ x, y, z }) {
     const firstFullImage = this.channelPyramids[0][0];
-    const minZoom = -1 * this.channelPyramids[0].length;
     const width = firstFullImage.getWidth();
     const height = firstFullImage.getHeight();
-    const tileSize = firstFullImage.getTileWidth();
-
-    const xInBounds = x < Math.ceil(width / (tileSize * 2 ** z)) && x >= 0;
-    const yInBounds = y < Math.ceil(height / (tileSize * 2 ** z)) && y >= 0;
-    const zInBounds = z >= 0 && z < -minZoom;
-
-    return xInBounds && yInBounds && zInBounds;
+    const { tileSize, numLevels } = this;
+    return isInTileBounds({
+      x,
+      y,
+      z,
+      width,
+      height,
+      tileSize,
+      numLevels
+    });
   }
 }

--- a/src/loaders/tiffPyramidLoader.js
+++ b/src/loaders/tiffPyramidLoader.js
@@ -49,20 +49,15 @@ export default class TiffPyramidLoader {
   }
 
   async getRaster({ z }) {
+    const width = this.channelPyramids[0][z].getWidth();
+    const height = this.channelPyramids[0][z].getHeight();
     const rasterRequests = this.channelPyramids.map(async channelPyramid => {
       const image = channelPyramid[z];
       const raster = await image.readRasters();
       return raster[0];
     });
-    const rasters = await Promise.all(rasterRequests);
-    return rasters;
-  }
-
-  getRasterSize({ z }) {
-    const image = this.channelPyramids[0][z];
-    const imageWidth = image.getWidth();
-    const imageHeight = image.getHeight();
-    return { imageWidth, imageHeight };
+    const data = await Promise.all(rasterRequests);
+    return { data, width, height };
   }
 
   async _getChannel({ image, x, y }) {

--- a/src/loaders/utils.js
+++ b/src/loaders/utils.js
@@ -1,0 +1,14 @@
+export function isInTileBounds({
+  x,
+  y,
+  z,
+  width,
+  height,
+  tileSize,
+  numLevels
+}) {
+  const xInBounds = x < Math.ceil(width / (tileSize * 2 ** z)) && x >= 0;
+  const yInBounds = y < Math.ceil(height / (tileSize * 2 ** z)) && y >= 0;
+  const zInBounds = z >= 0 && z < numLevels;
+  return xInBounds && yInBounds && zInBounds;
+}

--- a/src/loaders/zarrLoader.js
+++ b/src/loaders/zarrLoader.js
@@ -79,6 +79,8 @@ export default class ZarrLoader {
 
   async getRaster({ z }) {
     const source = this.isPyramid ? this._data[z] : this._data;
+    const height = source.shape[this.yIndex];
+    const width = source.shape[this.xIndex];
     const selection = [...this.chunkIndex];
     selection[this.xIndex] = null;
     selection[this.yIndex] = null;
@@ -87,16 +89,9 @@ export default class ZarrLoader {
     }
     const { data } = await source.getRaw(selection);
     if (this.channelChunkSize > 1) {
-      return this._decodeChannels(data);
+      return { data: this._decodeChannels(data), width, height };
     }
-    return [data];
-  }
-
-  getRasterSize({ z }) {
-    const source = z ? this._data[z] : this._base;
-    const imageHeight = source.shape[this.yIndex];
-    const imageWidth = source.shape[this.xIndex];
-    return { imageHeight, imageWidth };
+    return { data: [data], width, height };
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/loaders/zarrLoader.js
+++ b/src/loaders/zarrLoader.js
@@ -9,6 +9,7 @@ export default class ZarrLoader {
       [base] = data;
     } else {
       this.isPyramid = false;
+      this.numLevels = 1;
       base = data;
     }
     const { dtype } = base;

--- a/tests/StaticImageLayer.spec.js
+++ b/tests/StaticImageLayer.spec.js
@@ -27,12 +27,12 @@ test('StaticImageLayer', t => {
       ],
       channelIsOn: [true, false],
       loader: {
-        getRaster: () => [
-          new Uint32Array([0, 2, 1, 2]),
-          new Uint32Array([1, 2, 1, 2])
-        ],
-        dtype: '<u4',
-        getRasterSize: () => ({ imageHeight: 2, imageWidth: 2 })
+        getRaster: async () => ({
+          data: [new Uint32Array([0, 2, 1, 2]), new Uint32Array([1, 2, 1, 2])],
+          width: 2,
+          height: 2
+        }),
+        dtype: '<u4'
       }
     },
     onBeforeUpdate: ({ testCase }) => t.comment(testCase.title)

--- a/tests/StaticImageLayer.spec.js
+++ b/tests/StaticImageLayer.spec.js
@@ -31,7 +31,8 @@ test('StaticImageLayer', t => {
           new Uint32Array([0, 2, 1, 2]),
           new Uint32Array([1, 2, 1, 2])
         ],
-        vivMetadata: { imageHeight: 2, imageWidth: 2, dtype: '<u4' }
+        dtype: '<u4',
+        getRasterSize: () => ({ imageHeight: 2, imageWidth: 2 })
       }
     },
     onBeforeUpdate: ({ testCase }) => t.comment(testCase.title)

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -1,7 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies, no-unused-expressions */
 import test from 'tape-catch';
-import { range, isInTileBounds } from '../src/layers/VivViewerLayer/utils';
+import { range } from '../src/layers/VivViewerLayer/utils';
 import { padWithDefault, padColorsAndSliders } from '../src/layers/utils';
+import { isInTileBounds } from '../src/loaders/utils';
 
 test('range test', t => {
   const expected = [0, 1, 2];
@@ -151,10 +152,10 @@ test('isInTileBounds test', t => {
       x: 0,
       y: 0,
       z: 0,
-      imageWidth: 10,
-      imageHeight: 10,
+      width: 10,
+      height: 10,
       tileSize: 2,
-      minZoom: -5
+      numLevels: 5
     }),
     'Tile indices are in bounds given image dimensions'
   );
@@ -163,10 +164,10 @@ test('isInTileBounds test', t => {
       x: 0,
       y: 0,
       z: 6,
-      imageWidth: 10,
-      imageHeight: 10,
+      width: 10,
+      height: 10,
       tileSize: 2,
-      minZoom: -5
+      numLevels: 5
     }),
     'Tile indices are out of bounds because zoom level is less than minZoom'
   );
@@ -175,10 +176,10 @@ test('isInTileBounds test', t => {
       x: 5,
       y: 5,
       z: 0,
-      imageWidth: 10,
-      imageHeight: 10,
+      width: 10,
+      height: 10,
       tileSize: 2,
-      minZoom: -5
+      numLevels: 5
     }),
     'Tile indices are out of bounds because tile indices are too big for image dimensions.'
   );

--- a/tests/zarrLoader.spec.js
+++ b/tests/zarrLoader.spec.js
@@ -21,21 +21,14 @@ test('Test zarr non-rgb image loader', async t => {
     x: null
   };
   const loader = new ZarrLoader(z, isRgb, scale, dimensions);
-  // eslint-disable-next-line prefer-destructuring
-  const vivMetadata = loader.vivMetadata;
-  t.deepEqual(
-    Object.keys(vivMetadata).sort(),
-    ['dtype', 'imageHeight', 'imageWidth', 'minZoom', 'scale', 'tileSize'],
-    'Ensure viv-specific keys are returned by object.'
-  );
+  const { dtype, numLevels, tileSize } = loader;
+  t.equal(dtype, '<i4', 'Correct dtype');
+  t.equal(numLevels, 1, 'Correct number of levels');
+  t.equal(tileSize, 100, 'Correct tile size');
 
   let [tile] = await loader.getTile({ x: 0, y: 0 });
   t.equal(tile[10], 42, 'Fetch first tile and make sure correct value.');
-  t.equal(
-    tile.length,
-    vivMetadata.tileSize * vivMetadata.tileSize,
-    'Ensure correct tile sizes.'
-  );
+  t.equal(tile.length, tileSize * tileSize, 'Ensure correct tile sizes.');
 
   loader.setChunkIndex('channel', 1);
   [tile] = await loader.getTile({ x: 0, y: 0 });


### PR DESCRIPTION
I removed `loader.vivMetaData` from the loaders and now require the loaders to have the properties:

- `dtype`
- `tileSize` 
- `numLevels` - number of pyramidal levels

Also, for `StaticImageLayer` the loader must implement `loader.getRasterSize({z})` which returns `({imageWidth, imageHeight})` for a particular zoom level. 

Overall, I noticed that we were doing somethings within `viv` that were still more aware of the data source than I thought made sense. Let me explain.

For example, the reason that we needed `isTileInBounds` was to prevent making wrapping requests for x/y tile requests which is `geotiff`-specific and to avoid making requests for negative `bbox` values from deck.gl in `renderSubLayers`. Allowing wrapping behavoir makes sense in the geospatial case and the `geotiff` function `image.getTileOrStrip(x, y, 0)` handles making these wrapping requests. However, `zarr` will throw and error if you make a request beyond the boundary. Rather than redundantly checking bounds everytime, we can just handle the request error with the deck.gl function `onTileError`. This allows us to couple the library-specific handling of out of bounds requests within the loaders rather than viv. 

Therefore in viv, the main restriction that we impose is that tiles are only fetched in the positive coordinate system, but we don't need to have any extra bounding logic within the layers themselves.