### PR TITLE
Aysnc data in `StaticImageLayer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Generalize colormaps to multichannel maps.
 - Add flags to check for loader change and rerender.
 - Remove minZoom from loaders and make loaders provide `onTileError`.
+- Wrap `channelData` in `StaticImageLayer` in Promise.
 
 ## 0.1.3
 

--- a/src/layers/StaticImageLayer.js
+++ b/src/layers/StaticImageLayer.js
@@ -84,10 +84,10 @@ export default class StaticImageLayer extends CompositeLayer {
       scale
     });
 
-    if (!(data && width && height)) return null;
+    if (!(width && height)) return null;
 
     return new XRLayer({
-      channelData: data,
+      channelData: Promise.resolve(data),
       bounds,
       sliderValues: paddedSliderValues,
       colorValues: paddedColorValues,


### PR DESCRIPTION
Refactoring the `getRaster` function to return an image (`{data, width, height}`) and using `StaticImageLayer` to manage data changes made it so that loader change events were not registered in the `XRLayer` (i.e. changing a channel selection does not trigger new render),

This PR simply wraps the image data (managed by `StaticImageLayer`) in a Promise so that `XRLayer` checks for a new promise and can resolve and render.