### PR TITLE
Check for safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Display warning for Safari users
+
 ### Changed
 
 ## 0.1.4

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ uses Google Cloud Storage, which is HTTP2 by default.
 Due to difficulties around compiling shaders on Travis, unit tests and layer lifecycle
 tests are run locally as a pre-push hook. Travis runs a test build, linting, and prettier.
 
+## Browser Support
+
+Currently Safari lacks full WebGL2 support. The `Viv` component will display an error. To override the styling, add something like
+
+```css
+.viv-error p {
+  color: red;
+  margin: 15px;
+}
+```
+
 ## Component Library API
 
 There are two components being exported for use:

--- a/demo/src/App.css
+++ b/demo/src/App.css
@@ -32,3 +32,8 @@
 .slider-container p {
   color: white;
 }
+
+.viv-error p {
+  color: red;
+  margin: 15px;
+}

--- a/src/VivViewer.js
+++ b/src/VivViewer.js
@@ -4,6 +4,17 @@ import { OrthographicView } from '@deck.gl/core';
 import { VivViewerLayer, StaticImageLayer } from './layers';
 import VivViewerOverview from './VivViewerOverview';
 
+// Taken from https://stackoverflow.com/a/31732310/8060591
+function checkIsSafari() {
+  return (
+    navigator.vendor &&
+    navigator.vendor.indexOf('Apple') > -1 &&
+    navigator.userAgent &&
+    navigator.userAgent.indexOf('CriOS') === -1 &&
+    navigator.userAgent.indexOf('FxiOS') === -1
+  );
+}
+
 export default class VivViewer extends PureComponent {
   constructor(props) {
     super(props);
@@ -144,7 +155,7 @@ export default class VivViewer extends PureComponent {
     if (loader.isPyramid && overview) {
       views.push(overview.getView());
     }
-    return (
+    return !checkIsSafari() ? (
       <DeckGL
         glOptions={{ webgl2: true }}
         layerFilter={this.layerFilter}
@@ -153,6 +164,13 @@ export default class VivViewer extends PureComponent {
         views={views}
         viewState={this.state.viewState}
       />
+    ) : (
+      <div>
+        {' '}
+        <p style={{ color: 'red', margin: '15px' }}>
+          Viv does not work with Safari. Please use Chrome or Firefox.
+        </p>
+      </div>
     );
     /* eslint-disable react/destructuring-assignment */
   }

--- a/src/VivViewer.js
+++ b/src/VivViewer.js
@@ -165,11 +165,8 @@ export default class VivViewer extends PureComponent {
         viewState={this.state.viewState}
       />
     ) : (
-      <div>
-        {' '}
-        <p style={{ color: 'red', margin: '15px' }}>
-          Viv does not work with Safari. Please use Chrome or Firefox.
-        </p>
+      <div className="viv-error">
+        <p>Viv does not work with Safari. Please use Chrome or Firefox.</p>
       </div>
     );
     /* eslint-disable react/destructuring-assignment */

--- a/src/VivViewer.js
+++ b/src/VivViewer.js
@@ -5,7 +5,7 @@ import { VivViewerLayer, StaticImageLayer } from './layers';
 import VivViewerOverview from './VivViewerOverview';
 
 // Taken from https://stackoverflow.com/a/31732310/8060591
-function checkIsSafari() {
+function isSafari() {
   return (
     navigator.vendor &&
     navigator.vendor.indexOf('Apple') > -1 &&
@@ -155,7 +155,7 @@ export default class VivViewer extends PureComponent {
     if (loader.isPyramid && overview) {
       views.push(overview.getView());
     }
-    return !checkIsSafari() ? (
+    return !isSafari() ? (
       <DeckGL
         glOptions={{ webgl2: true }}
         layerFilter={this.layerFilter}
@@ -166,7 +166,10 @@ export default class VivViewer extends PureComponent {
       />
     ) : (
       <div className="viv-error">
-        <p>Viv does not work with Safari. Please use Chrome or Firefox.</p>
+        <p>
+          Safari does not support WebGL2, which Viv requires. Please use Chrome
+          or Firefox.
+        </p>
       </div>
     );
     /* eslint-disable react/destructuring-assignment */


### PR DESCRIPTION
Fixes #116, but different than asked.  As per [React docs](https://reactjs.org/docs/hooks-faq.html#do-hooks-cover-all-use-cases-for-classes), hooks do not currently support catching children errors, so I think the component displaying an error is good.  Do you think we should go differently?  I suppose we could throw an error, and then tell people to wrap the component in a class based component to catch the error.  I think this solution allows for people to style the error with css, but I could have that wrong.

<img width="1326" alt="Screen Shot 2020-04-09 at 4 02 23 PM" src="https://user-images.githubusercontent.com/43999641/78937376-665c1480-7a7e-11ea-8ec9-ebe84f886fb4.png">
