### PR TITLE
Remove `loader.serializeSelection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Removed `loader.serializeSelection` and standardized `loaderSelection` for `getTile` and `getRaster`
+
 ## 0.1.7
 
 ### Added

--- a/demo/src/utils.js
+++ b/demo/src/utils.js
@@ -111,7 +111,7 @@ export function channelsReducer(state, { index, value, type }) {
     }
     case 'RESET_CHANNELS': {
       // Clears current channels and sets with new defaults
-      const { names, selections = [] } = value;
+      const { names, selections } = value;
       const n = names.length;
       return {
         names,

--- a/docs/SAMPLES.md
+++ b/docs/SAMPLES.md
@@ -15,30 +15,32 @@ const loader = await createZarrLoader({
   isPyramid: true
 });
 
-const sliders = [[0,2000], [0,2000]]
-const colors = [[255, 0, 0], [0, 255, 0]]
-const isOn = [true, false]
-const selections = [[1, 0, 0], [2, 0, 0]]
+const sliders = [[0,2000], [0,2000]];
+const colors = [[255, 0, 0], [0, 255, 0]];
+const isOn = [true, false];
+const selections = [{ channel: 0 }, { channel: 1 }];
 const initialViewState = {
   height: 1000,
   width: 500,
   zoom: -5,
   target: [10000, 10000, 0].
-}
-const colormap = ''
-const panLock = true
-const zoomLock = false
-const linkedDetailViewer = <SideBySideViewer
-  loader={loader}
-  sliderValues={sliders}
-  colorValues={colors}
-  channelIsOn={isOn}
-  loaderSelection={selections}
-  initialViewState={initialViewState}
-  colormap={colormap.length > 0 && colormap}
-  zoomLock={zoomLock}
-  panLock={panLock}
-/>
+};
+const colormap = '';
+const panLock = true;
+const zoomLock = false;
+const linkedDetailViewer = (
+  <SideBySideViewer
+    loader={loader}
+    sliderValues={sliders}
+    colorValues={colors}
+    channelIsOn={isOn}
+    loaderSelection={selections}
+    initialViewState={initialViewState}
+    colormap={colormap.length > 0 && colormap}
+    zoomLock={zoomLock}
+    panLock={panLock}
+  />
+);
 ```
 
 #### `PictureInPictureViewer`
@@ -68,30 +70,32 @@ const zarrInfo = {
   ...basePyramidInfo,
 };
 const loader = await createZarrLoader(zarrInfo);
-const sliders = [[0,2000], [0,2000]]
-const colors = [[255, 0, 0], [0, 255, 0]]
-const isOn = [true, false]
-const selections = [[1, 0, 0], [2, 0, 0]]
+const sliders = [[0,2000], [0,2000]];
+const colors = [[255, 0, 0], [0, 255, 0]];
+const isOn = [true, false];
+const selections = [{ channel: 1 }, { channel: 2 }];
 const initialViewState = {
   height: 1000,
   width: 500,
   zoom: -5,
   target: [10000, 10000, 0].
-}
-const colormap = ''
+};
+const colormap = '';
 const overview = {
   boundingBoxColor: [0, 0, 255]
-}
-const overviewOn = true
-const PictureInPictureViewer = <PictureInPictureViewer
-  loader={loader}
-  sliderValues={sliders}
-  colorValues={colors}
-  channelIsOn={isOn}
-  loaderSelection={selections}
-  initialViewState={initialViewState}
-  colormap={colormap.length > 0 && colormap}
-  overview={overview}
-  overviewOn={overviewOn}
-/>
+};
+const overviewOn = true;
+const PictureInPictureViewer = (
+  <PictureInPictureViewer
+    loader={loader}
+    sliderValues={sliders}
+    colorValues={colors}
+    channelIsOn={isOn}
+    loaderSelection={selections}
+    initialViewState={initialViewState}
+    colormap={colormap.length > 0 && colormap}
+    overview={overview}
+    overviewOn={overviewOn}
+  />
+);
 ```

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -1,69 +1,13 @@
 import OMEXML from './omeXML';
-import { isInTileBounds } from './utils';
+import { isInTileBounds, flipEndianness } from './utils';
 import { DTYPE_VALUES } from '../constants';
-// Credit to https://github.com/zbjornson/node-bswap/blob/master/bswap.js for the implementation.
-// I could not get this to import, and it doesn't appear anyone else can judging by the "Used by" on github.
-// We need this for handling the endianness returned by geotiff since it only returns bytes.
-function flip16(info) {
-  const flipper = new Uint8Array(info.buffer, info.byteOffset, info.length * 2);
-  const len = flipper.length;
-  for (let i = 0; i < len; i += 2) {
-    const t = flipper[i];
-    flipper[i] = flipper[i + 1];
-    flipper[i + 1] = t;
-  }
-}
 
-function flip32(info) {
-  const flipper = new Uint8Array(info.buffer, info.byteOffset, info.length * 4);
-  const len = flipper.length;
-  for (let i = 0; i < len; i += 4) {
-    let t = flipper[i];
-    flipper[i] = flipper[i + 3];
-    flipper[i + 3] = t;
-    t = flipper[i + 1];
-    flipper[i + 1] = flipper[i + 2];
-    flipper[i + 2] = t;
-  }
-}
-
-function flip64(info) {
-  const flipper = new Uint8Array(info.buffer, info.byteOffset, info.length * 8);
-  const len = flipper.length;
-  for (let i = 0; i < len; i += 8) {
-    let t = flipper[i];
-    flipper[i] = flipper[i + 7];
-    flipper[i + 7] = t;
-    t = flipper[i + 1];
-    flipper[i + 1] = flipper[i + 6];
-    flipper[i + 6] = t;
-    t = flipper[i + 2];
-    flipper[i + 2] = flipper[i + 5];
-    flipper[i + 5] = t;
-    t = flipper[i + 3];
-    flipper[i + 3] = flipper[i + 4];
-    flipper[i + 4] = t;
-  }
-}
-
-function flipEndianness(arr) {
-  switch (arr.BYTES_PER_ELEMENT) {
-    case 1:
-      // no op
-      return;
-    case 2:
-      flip16(arr);
-      break;
-    case 4:
-      flip32(arr);
-      break;
-    case 8:
-      flip64(arr);
-      break;
-    default:
-      throw new Error('Invalid input');
-  }
-}
+const DTYPE_LOOKUP = {
+  uint8: '<u1',
+  uint16: '<u2',
+  uint32: '<u4',
+  float32: '<f4'
+};
 
 /**
  * This class serves as a wrapper for fetching tiff data from a file server.
@@ -96,21 +40,9 @@ export default class OMETiffLoader {
     this.isBioFormats6Pyramid = SubIFDs;
     this.isPyramid = this.numLevels > 1;
 
-    const type = this.omexml.Type;
     // We use zarr's internal format.  It encodes endiannes, but we leave it little for now
     // since javascript is little endian.
-    if (type === 'uint8') {
-      this.dtype = '<u1';
-    }
-    if (type === 'uint16') {
-      this.dtype = '<u2';
-    }
-    if (type === 'uint32') {
-      this.dtype = '<u4';
-    }
-    if (type === 'float32') {
-      this.dtype = '<f4';
-    }
+    this.dtype = DTYPE_LOOKUP[this.omexml.Type];
   }
 
   /**
@@ -182,7 +114,8 @@ export default class OMETiffLoader {
     const { SizeZ, SizeT, SizeC } = omexml;
     const pyramidOffset = z * SizeZ * SizeT * SizeC;
     let image;
-    const tileRequests = loaderSelection.map(async index => {
+    const tileRequests = loaderSelection.map(async sel => {
+      const index = this._getIFDIndex(sel);
       const pyramidIndex = pyramidOffset + index;
       // We need to put the request for parsing the file directory into this array.
       // This allows us to get tiff pages directly based on offset without parsing everything.
@@ -225,7 +158,8 @@ export default class OMETiffLoader {
     const { tiff, offsets, omexml, isBioFormats6Pyramid, poolOrDecoder } = this;
     const { SizeZ, SizeT, SizeC } = omexml;
     const rasters = await Promise.all(
-      loaderSelection.map(async index => {
+      loaderSelection.map(async sel => {
+        const index = this._getIFDIndex(sel);
         const pyramidIndex = z * SizeZ * SizeT * SizeC + index;
         // We need to put the request for parsing the file directory into this array.
         // This allows us to get tiff pages directly based on offset without parsing everything.
@@ -251,7 +185,7 @@ export default class OMETiffLoader {
     );
     // Get first selectioz * SizeZ * SizeT * SizeC + loaderSelection[0]n size as proxy for image size.
     const image = await tiff.getImage(
-      z * SizeZ * SizeT * SizeC + loaderSelection[0]
+      z * SizeZ * SizeT * SizeC + this._getIFDIndex(loaderSelection[0])
     );
     const width = image.getWidth();
     const height = image.getHeight();
@@ -288,35 +222,6 @@ export default class OMETiffLoader {
       flipEndianness(data);
     }
     return data;
-  }
-
-  /**
-   * Converts Array of loader selection objects into an IFD index.
-   *
-   * Ex.
-   *  const loaderSelectionObj = [
-   *     { time: 1, channel: 'a', z: 0 },
-   *     { time: 1, channel: 'b', z: 0 }
-   *  ];
-   *  const serialized = loader.serializeSelection(loaderSelectionObj);
-   *  console.log(serialized);
-   *  // 4, 5
-   *
-   * @param {Array || Object} loaderSelectionObjs Human-interpretable array of desired selection objects
-   * @returns {Array} number[][], IFD indices for selecting an image of the tiff.
-   */
-  serializeSelection(loaderSelectionObjs) {
-    // Wrap selection in array if only one is provided
-    const selectionObjs = Array.isArray(loaderSelectionObjs)
-      ? loaderSelectionObjs
-      : [loaderSelectionObjs];
-    const serialized = selectionObjs.map(obj => this._serialize(obj));
-    return serialized;
-  }
-
-  _serialize(selectionObj) {
-    const serializedSelection = this._getIFDIndex(selectionObj);
-    return serializedSelection;
   }
 
   _tileInBounds({ x, y, z }) {

--- a/src/loaders/utils.js
+++ b/src/loaders/utils.js
@@ -17,3 +17,67 @@ export function guessRgb(shape) {
   const lastDimSize = shape[shape.length - 1];
   return shape.length > 2 && (lastDimSize === 3 || lastDimSize === 4);
 }
+
+// Credit to https://github.com/zbjornson/node-bswap/blob/master/bswap.js for the implementation.
+// I could not get this to import, and it doesn't appear anyone else can judging by the "Used by" on github.
+// We need this for handling the endianness returned by geotiff since it only returns bytes.
+function flip16(info) {
+  const flipper = new Uint8Array(info.buffer, info.byteOffset, info.length * 2);
+  const len = flipper.length;
+  for (let i = 0; i < len; i += 2) {
+    const t = flipper[i];
+    flipper[i] = flipper[i + 1];
+    flipper[i + 1] = t;
+  }
+}
+
+function flip32(info) {
+  const flipper = new Uint8Array(info.buffer, info.byteOffset, info.length * 4);
+  const len = flipper.length;
+  for (let i = 0; i < len; i += 4) {
+    let t = flipper[i];
+    flipper[i] = flipper[i + 3];
+    flipper[i + 3] = t;
+    t = flipper[i + 1];
+    flipper[i + 1] = flipper[i + 2];
+    flipper[i + 2] = t;
+  }
+}
+
+function flip64(info) {
+  const flipper = new Uint8Array(info.buffer, info.byteOffset, info.length * 8);
+  const len = flipper.length;
+  for (let i = 0; i < len; i += 8) {
+    let t = flipper[i];
+    flipper[i] = flipper[i + 7];
+    flipper[i + 7] = t;
+    t = flipper[i + 1];
+    flipper[i + 1] = flipper[i + 6];
+    flipper[i + 6] = t;
+    t = flipper[i + 2];
+    flipper[i + 2] = flipper[i + 5];
+    flipper[i + 5] = t;
+    t = flipper[i + 3];
+    flipper[i + 3] = flipper[i + 4];
+    flipper[i + 4] = t;
+  }
+}
+
+export function flipEndianness(arr) {
+  switch (arr.BYTES_PER_ELEMENT) {
+    case 1:
+      // no op
+      return;
+    case 2:
+      flip16(arr);
+      break;
+    case 4:
+      flip32(arr);
+      break;
+    case 8:
+      flip64(arr);
+      break;
+    default:
+      throw new Error('Invalid input');
+  }
+}

--- a/src/loaders/zarrLoader.js
+++ b/src/loaders/zarrLoader.js
@@ -136,7 +136,7 @@ export default class ZarrLoader {
     if (Array.isArray(selection)) return [...selection];
 
     const serialized = Array(this.dimensions.length).fill(0);
-    for (const [dimName, value] of Object.entries(selection)) {
+    Object.entries(selection).forEach(([dimName, value]) => {
       if (!this._dimIndices.has(dimName)) {
         throw Error(
           `Dimension "${dimName}" does not exist on loader.
@@ -169,7 +169,7 @@ export default class ZarrLoader {
           );
         }
       }
-    }
+    });
     return serialized;
   }
 }

--- a/src/loaders/zarrLoader.js
+++ b/src/loaders/zarrLoader.js
@@ -27,17 +27,12 @@ export default class ZarrLoader {
     this._defaultSelection = [Array(dimensions.legnth).fill(0)];
 
     this._data = data;
-    if (this.isRgb) {
-      this._xIndex = base.shape.length - 2;
-      this._yIndex = base.shape.length - 3;
-    } else {
-      this._xIndex = base.shape.length - 1;
-      this._yIndex = base.shape.length - 2;
-    }
+    this._dimIndices = new Map();
+    dimensions.forEach(({ field }, i) => this._dimIndices.set(field, i));
 
     const { dtype, chunks } = base;
     this.dtype = dtype;
-    this.tileSize = chunks[this._xIndex];
+    this.tileSize = chunks[this._dimIndices.get('x')];
   }
 
   get isPyramid() {
@@ -53,16 +48,16 @@ export default class ZarrLoader {
    * @param {number} x positive integer
    * @param {number} y positive integer
    * @param {number} z positive integer (0 === highest zoom level)
-   * @param {Array} loaderSelection, Array of number Arrays specifying channel selections
+   * @param {Array} loaderSelection, Array of valid dimension selections
    * @returns {Object} data: TypedArray[], width: number (tileSize), height: number (tileSize)
    */
   async getTile({ x, y, z, loaderSelection }) {
     const source = this._getSource(z);
     const selections = loaderSelection || this._defaultSelection;
-    const dataRequests = selections.map(async key => {
-      const chunkKey = [...key];
-      chunkKey[this._yIndex] = y;
-      chunkKey[this._xIndex] = x;
+    const dataRequests = selections.map(async sel => {
+      const chunkKey = this._serializeSelection(sel);
+      chunkKey[this._dimIndices.get('y')] = y;
+      chunkKey[this._dimIndices.get('x')] = x;
       const { data } = await source.getRawChunk(chunkKey);
       return data;
     });
@@ -73,24 +68,25 @@ export default class ZarrLoader {
   /**
    * Returns full image panes (at level z if pyramid)
    * @param {number} z positive integer (0 === highest zoom level)
-   * @param {Array} loaderSelection, Array of number Arrays specifying channel selections
+   * @param {Array} loaderSelection, Array of valid dimension selections
    * @returns {Object} data: TypedArray[], width: number, height: number
    */
   async getRaster({ z, loaderSelection }) {
     const source = this._getSource(z);
+    const [xIndex, yIndex] = ['x', 'y'].map(k => this._dimIndices.get(k));
     const selections = loaderSelection || this._defaultSelection;
-    const dataRequests = selections.map(async key => {
-      const chunkKey = [...key];
-      chunkKey[this._yIndex] = null;
-      chunkKey[this._xIndex] = null;
+    const dataRequests = selections.map(async sel => {
+      const chunkKey = this._serializeSelection(sel);
+      chunkKey[yIndex] = null;
+      chunkKey[xIndex] = null;
       if (this.isRgb) chunkKey[chunkKey.length - 1] = null;
       const { data } = await source.getRaw(chunkKey);
       return data;
     });
     const data = await Promise.all(dataRequests);
     const { shape } = source;
-    const width = shape[this._xIndex];
-    const height = shape[this._yIndex];
+    const width = shape[xIndex];
+    const height = shape[yIndex];
     return { data, width, height };
   }
 
@@ -116,76 +112,64 @@ export default class ZarrLoader {
    */
   getRasterSize({ z }) {
     const source = this._getSource(z);
-    const height = source.shape[this._yIndex];
-    const width = source.shape[this._xIndex];
+    const [height, width] = ['y', 'x'].map(
+      k => source.shape[this._dimIndices.get(k)]
+    );
     return { height, width };
-  }
-
-  /**
-   * Converts Array of loader selection objects into zarr-specific selection
-   *
-   * Ex.
-   *  const loaderSelectionObj = [
-   *     { time: 1, channel: 'a' },
-   *     { time: 1, channel: 'b' }
-   *  ];
-   *  const serialized = loader.serializeSelection(loaderSelectionObj);
-   *  console.log(serialized);
-   *  // [[1, 0, 0, 0], [1, 1, 0, 0]]
-   *
-   * @param {Array || Object} loaderSelectionObjs Human-interpretable array of desired selection objects
-   * @returns {Array} number[][], zarr-specific selections to be passed to to viv as loaderSelections
-   */
-  serializeSelection(loaderSelectionObjs) {
-    // Wrap selection in array if only one is provided
-    const selectionObjs = Array.isArray(loaderSelectionObjs)
-      ? loaderSelectionObjs
-      : [loaderSelectionObjs];
-
-    const serialized = selectionObjs.map(obj => this._serialize(obj));
-    return serialized;
   }
 
   _getSource(z) {
     return typeof z === 'number' && this.isPyramid ? this._data[z] : this._data;
   }
 
-  _serialize(selectionObj) {
-    const serializedSelection = Array(this.dimensions.length).fill(0);
-    const dimFields = this.dimensions.map(d => d.field);
-    Object.entries(selectionObj).forEach(([key, val]) => {
-      // Get index of named dimension in zarr array
-      const dimIndex = dimFields.indexOf(key);
-      if (dimIndex === undefined) {
+  /**
+   * Returns valid zarr.js selection for ZarrArray.getRaw or ZarrArray.getRawChunk
+   * @param {Object} selection valid dimension selection
+   * @returns {Array} Array of indicies
+   *
+   * Valid dimension selections include:
+   *   - Direct zarr.js selection: [1, 0, 0, 0]
+   *   - Named selection object: { channel: 0, time: 2 } or { channel: "DAPI", time: 2 }
+   */
+  _serializeSelection(selection) {
+    // Just return copy if array-like zarr.js selection
+    if (Array.isArray(selection)) return [...selection];
+
+    const serialized = Array(this.dimensions.length).fill(0);
+    for (const [dimName, value] of Object.entries(selection)) {
+      if (!this._dimIndices.has(dimName)) {
         throw Error(
-          `Dimension '${key}' does not exist on array with dimensions :
-          ${dimFields}`
+          `Dimension "${dimName}" does not exist on loader.
+           Must be one of "${this.dimensions.map(d => d.field)}."`
         );
       }
-      // Get position of index along dimension axis
-      let valueIndex;
-      const { field, type, values } = this.dimensions[dimIndex];
-      if (typeof val === 'number') {
-        // Assign index directly, regardless of dimension type
-        valueIndex = val;
-      } else if (type === 'ordinal' || type === 'nominal') {
-        // Lookup index if categorical dimension type.
-        // This is slower if dimension is large; setting directly is preferred.
-        valueIndex = values.indexOf(val);
-      } else {
-        // Cannot use string value for dimension that is 'quantitative' or 'temporal', must set directly.
-        throw Error(
-          `The value '${val}' is invalid for dimension of type ${type}`
-        );
+      const dimIndex = this._dimIndices.get(dimName);
+      switch (typeof value) {
+        case 'number': {
+          // ex. { channel: 0 }
+          serialized[dimIndex] = value;
+          break;
+        }
+        case 'string': {
+          const { values, type } = this.dimensions[dimIndex];
+          if (type === 'nominal' || type === 'ordinal') {
+            // ex. { channel: 'DAPI' }
+            serialized[dimIndex] = values.indexOf(value);
+            break;
+          } else {
+            // { z: 'DAPI' }
+            throw Error(
+              `Cannot use selection "${value}" for dimension "${dimName}" with type "${type}".`
+            );
+          }
+        }
+        default: {
+          throw Error(
+            `Named selection must be a string or number. Got ${value} for ${dimName}.`
+          );
+        }
       }
-
-      if (valueIndex < 0 || valueIndex > this.base.shape[dimIndex]) {
-        // Ensure desired index is within the bounds of the dimension
-        throw Error(`Dimension ${field} does not contain index ${valueIndex}.`);
-      }
-
-      serializedSelection[dimIndex] = valueIndex;
-    });
-    return serializedSelection;
+    }
+    return serialized;
   }
 }

--- a/tests/loaders/OMETiffLoader.spec.js
+++ b/tests/loaders/OMETiffLoader.spec.js
@@ -35,8 +35,8 @@ describe('Test multi-channel input', () => {
       omexmlString,
       offsets: [8, 2712, 4394]
     });
-    const selection = loader.serializeSelection([{ channel: 1 }]);
+    const selection = loader._getIFDIndex({ channel: 1 });
 
-    expect(selection).to.deep.equal([1]);
+    expect(selection).to.deep.equal(1);
   });
 });

--- a/tests/loaders/zarrLoader.spec.js
+++ b/tests/loaders/zarrLoader.spec.js
@@ -44,7 +44,11 @@ describe('Test zarr non-rgb image loader', () => {
     expect(res.data[0][10]).to.equal(42);
     expect(res.data[0].length).to.equal(tileSize * tileSize);
 
-    res = await loader.getTile({ x: 0, y: 0, loaderSelection: [[1, 0, 0]] });
+    res = await loader.getTile({
+      x: 0,
+      y: 0,
+      loaderSelection: [{ channel: 1 }]
+    });
     expect(res.data[0].subarray(0, 100)).to.deep.equal(
       NestedArray.arange(100).flatten()
     );


### PR DESCRIPTION
Removes `loader.serializeSelection` in favor of standardizing what `loaderSelection` is for the `loader.getTile` and `loader.getRaster` callbacks.