### PR TITLE
Add a dimension builder onto the tiff loader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Remove threads.js and use WebWorkers for tiff decompression.
+- Add a dimension builder onto the tiff loader.
 
 ### Changed
 

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -49,7 +49,6 @@ export default class OMETiffLoader {
       { field: 'x', type: 'quantitative', values: null },
       { field: 'y', type: 'quantitative', values: null }
     ];
-    const type = this.omexml.Type;
     // We use zarr's internal format.  It encodes endiannes, but we leave it little for now
     // since javascript is little endian.
     this.dtype = DTYPE_LOOKUP[this.omexml.Type];

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -1,6 +1,7 @@
 import OMEXML from './omeXML';
 import { isInTileBounds } from './utils';
 import { DTYPE_VALUES } from '../constants';
+import { range } from '../layers/utils';
 
 // Credit to https://github.com/zbjornson/node-bswap/blob/master/bswap.js for the implementation.
 // I could not get this to import, and it doesn't appear anyone else can judging by the "Used by" on github.
@@ -100,8 +101,8 @@ export default class OMETiffLoader {
     // is for unifying the two loaders in upstream applications.
     this.dimensions = [
       { field: 'channel', type: 'nominal', values: this.channelNames },
-      { field: 'z', type: 'number', values: null },
-      { field: 'time', type: 'number', values: null },
+      { field: 'z', type: 'ordinal', values: range(this.omexml.SizeZ) },
+      { field: 'time', type: 'ordinal', values: range(this.omexml.SizeT) },
       { field: 'x', type: 'quantitative', values: null },
       { field: 'y', type: 'quantitative', values: null }
     ];

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -1,6 +1,7 @@
 import OMEXML from './omeXML';
 import { isInTileBounds } from './utils';
 import { DTYPE_VALUES } from '../constants';
+
 // Credit to https://github.com/zbjornson/node-bswap/blob/master/bswap.js for the implementation.
 // I could not get this to import, and it doesn't appear anyone else can judging by the "Used by" on github.
 // We need this for handling the endianness returned by geotiff since it only returns bytes.
@@ -95,7 +96,15 @@ export default class OMETiffLoader {
       this.omexml.getNumberOfImages() || (SubIFDs && SubIFDs.length);
     this.isBioFormats6Pyramid = SubIFDs;
     this.isPyramid = this.numLevels > 1;
-
+    // The omexml specification only allows for these - zarr is more flexible so this
+    // is for unifying the two loaders in upstream applications.
+    this.dimensions = [
+      { field: 'channel', type: 'nominal', values: this.channelNames },
+      { field: 'z', type: 'number', values: null },
+      { field: 'time', type: 'number', values: null },
+      { field: 'x', type: 'quantitative', values: null },
+      { field: 'y', type: 'quantitative', values: null }
+    ];
     const type = this.omexml.Type;
     // We use zarr's internal format.  It encodes endiannes, but we leave it little for now
     // since javascript is little endian.


### PR DESCRIPTION
I am adding a dimension builder here for the OMETIFF loader.  When I start doing the CODEX integration with Vitessce, Vitessce will need a way of inferring dimensions rather than pulling them from an external schema like `xxx.rasters.json`.  Does this make sense?  Even if this isn't the final product, it can serve as a starting point that I can iterate on with CODEX.  