### PR TITLE
Not all ometiff have StructuredAnnotations...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Address OMEXML discrepancy on StructuredAnnotations.
+
 ## 0.2.4
 
 ### Added

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -300,9 +300,10 @@ export default class OMETiffLoader {
     let roiCount;
     if (StructuredAnnotations) {
       const { MapAnnotation } = StructuredAnnotations;
-      roiCount = MapAnnotation && MapAnnotation.Value
-        ? Object.entries(MapAnnotation.Value).length
-        : 0;
+      roiCount =
+        MapAnnotation && MapAnnotation.Value
+          ? Object.entries(MapAnnotation.Value).length
+          : 0;
     }
     return {
       'Acquisition Date': AcquisitionDate,

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -269,7 +269,7 @@ export default class OMETiffLoader {
     const {
       metadataOMEXML: {
         Image: { AcquisitionDate },
-        StructuredAnnotations: { MapAnnotation }
+        StructuredAnnotations
       },
       SizeX,
       SizeY,
@@ -297,11 +297,13 @@ export default class OMETiffLoader {
       PhysicalSizeZ && PhysicalSizeZUnit
         ? `${PhysicalSizeZ} (${PhysicalSizeZUnit})`
         : '-';
-    const roiCount =
-      MapAnnotation && MapAnnotation.Value
+    let roiCount;
+    if (StructuredAnnotations) {
+      const { MapAnnotation } = StructuredAnnotations;
+      roiCount = MapAnnotation && MapAnnotation.Value
         ? Object.entries(MapAnnotation.Value).length
         : 0;
-
+    }
     return {
       'Acquisition Date': AcquisitionDate,
       'Dimensions (XY)': `${SizeX} x ${SizeY}`,


### PR DESCRIPTION
Was getting this error in Vitessce because StructuredAnnotations is not defined in the OMEXML for the CODEX data.  Tested out locally in Viv and confirmed the fix with each OME-TIFF demo file.

<img width="1660" alt="Screen Shot 2020-05-15 at 11 26 11 AM" src="https://user-images.githubusercontent.com/43999641/82067566-e63d5600-969e-11ea-8945-b1392f2446ba.png">
