### PR TITLE
Remove Bioformats Hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Don't minify es bundle.
+- Remove bioformats hack.
 
 ## 0.2.5
 

--- a/demo/src/source-info.js
+++ b/demo/src/source-info.js
@@ -20,7 +20,7 @@ const basePyramidInfo = {
 
 // Generated using bioformats2raw and raw2ometiff.
 const tiffInfo = {
-  url: `https://vitessce-demo-data.storage.googleapis.com/test-data/spraggins.bioformats.raw2ometiff.ome.tif`,
+  url: `https://vitessce-demo-data.storage.googleapis.com/test-data/hubmap/pyramid_0.0.2/spraggins.ome.tif`,
   ...basePyramidInfo,
   description: 'Kidney mxIF (OME-TIFF)'
 };
@@ -179,7 +179,7 @@ const remoteBFTiff = {
 
 // Generated using bioformats2raw and raw2ometiff.
 const remoteTiffUrl2 =
-  'https://vitessce-demo-data.storage.googleapis.com/test-data/test_VAN0003-LK-32-21-AF_preIMS_registered.ome.tif';
+  'https://vitessce-demo-data.storage.googleapis.com/test-data/hubmap/pyramid_0.0.2/VAN0003-LK-32-21-AF_preIMS_registered.ome.tif';
 
 const remoteTiff2 = {
   url: remoteTiffUrl2,

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -60,7 +60,6 @@ export default class VivViewerLayer extends CompositeLayer {
     };
     const tiledLayer = new VivViewerLayerBase({
       id: `Tiled-Image-${id}`,
-      tileSize,
       getTileData,
       dtype,
       minZoom: -(numLevels - 1),
@@ -82,11 +81,7 @@ export default class VivViewerLayer extends CompositeLayer {
       colormap,
       viewportId,
       onHover,
-      pickable,
-      width,
-      height,
-      // Needed for misreported metadata in bioformats.
-      loader
+      pickable
     });
     // This gives us a background image and also solves the current
     // minZoom funny business.  We don't use it for the background if we have an opacity

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -41,7 +41,7 @@ export default class VivViewerLayer extends CompositeLayer {
       pickable,
       id
     } = this.props;
-    const { tileSize, numLevels, dtype, width, height } = loader;
+    const { tileSize, numLevels, dtype } = loader;
     const getTileData = async ({ x, y, z }) => {
       const tile = await loader.getTile({
         x,
@@ -62,6 +62,7 @@ export default class VivViewerLayer extends CompositeLayer {
       id: `Tiled-Image-${id}`,
       getTileData,
       dtype,
+      tileSize,
       minZoom: -(numLevels - 1),
       colorValues,
       sliderValues,

--- a/src/layers/VivViewerLayer/VivViewerLayerBase.js
+++ b/src/layers/VivViewerLayer/VivViewerLayerBase.js
@@ -9,7 +9,6 @@ const defaultProps = {
   sliderValues: { type: 'array', value: [], compare: true },
   colorValues: { type: 'array', value: [], compare: true },
   channelIsOn: { type: 'array', value: [], compare: true },
-  tileSize: { type: 'number', value: 512, compare: true },
   minZoom: { type: 'number', value: 0, compare: true },
   maxZoom: { type: 'number', value: 0, compare: true },
   renderSubLayers: { type: 'function', value: renderSubLayers, compare: false },

--- a/src/layers/VivViewerLayer/utils.js
+++ b/src/layers/VivViewerLayer/utils.js
@@ -1,5 +1,4 @@
 import XRLayer from '../XRLayer';
-import { isBioformatsNoPadHeightVersion } from '../../loaders/utils';
 
 export function range(len) {
   return [...Array(len).keys()];
@@ -7,9 +6,7 @@ export function range(len) {
 
 export function renderSubLayers(props) {
   const {
-    bbox: { left, top, right, bottom },
-    y,
-    z
+    bbox: { left, top, right, bottom }
   } = props.tile;
   const {
     colorValues,
@@ -20,10 +17,7 @@ export function renderSubLayers(props) {
     data,
     colormap,
     dtype,
-    height,
-    tileSize,
     id,
-    loader,
     onHover,
     pickable
   } = props;
@@ -33,15 +27,7 @@ export function renderSubLayers(props) {
   }
   const xrl = new XRLayer({
     id: `XRLayer-${left}-${top}-${right}-${bottom}-${id}`,
-    bounds: [
-      left,
-      // This is a hack for now since bioformats mis-reports their data lower bound data.
-      loader && isBioformatsNoPadHeightVersion(loader.software)
-        ? Math.min(height, (y + 1) * tileSize * 2 ** (-1 * z))
-        : bottom,
-      right,
-      top
-    ],
+    bounds: [left, bottom, right, top],
     channelData: data,
     pickable,
     // Uncomment to help debugging - shades the tile being hovered over.

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -18,7 +18,6 @@ const defaultProps = {
   colorValues: { type: 'array', value: [], compare: true },
   sliderValues: { type: 'array', value: [], compare: true },
   channelIsOn: { type: 'array', value: [], compare: true },
-  tileSize: { type: 'number', value: 0, compare: true },
   opacity: { type: 'number', value: 1, compare: true },
   dtype: { type: 'string', value: '<u2', compare: true },
   colormap: { type: 'string', value: '', compare: true }

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -1,9 +1,5 @@
 import OMEXML from './omeXML';
-import {
-  isInTileBounds,
-  flipEndianness,
-  isBioformatsNoPadHeightVersion
-} from './utils';
+import { isInTileBounds, flipEndianness } from './utils';
 import { DTYPE_VALUES } from '../constants';
 import { range } from '../layers/utils';
 
@@ -150,7 +146,7 @@ export default class OMETiffLoader {
     if (!this._tileInBounds({ x, y, z })) {
       return null;
     }
-    const { tiff, isBioFormats6Pyramid, omexml, tileSize, software } = this;
+    const { tiff, isBioFormats6Pyramid, omexml, tileSize } = this;
     const { SizeZ, SizeT, SizeC } = omexml;
     const pyramidOffset = z * SizeZ * SizeT * SizeC;
     let image;
@@ -183,13 +179,10 @@ export default class OMETiffLoader {
       };
     }
     const tiles = await Promise.all(tileRequests);
-    const { ImageLength } = image.fileDirectory;
     return {
       data: tiles,
       width: tileSize,
-      height: isBioformatsNoPadHeightVersion(software)
-        ? Math.min(tileSize, ImageLength - y * tileSize)
-        : tileSize
+      height: tileSize
     };
   }
 

--- a/src/loaders/utils.js
+++ b/src/loaders/utils.js
@@ -81,24 +81,3 @@ export function flipEndianness(arr) {
       throw new Error('Invalid input');
   }
 }
-
-const NO_PAD_BIOFORMATS_VERSION = [6, 2, 1];
-
-export function isBioformatsNoPadHeightVersion(software) {
-  if (!software) {
-    return false;
-  }
-  const isBioFormats = software.includes('Bio-Formats');
-  const version = software.match(/[0-9]/g).map(e => Number(e));
-  // Guessing that bioformats 6.0.0 - 6.2.1 misreports bounds, we check the major version.
-  if (isBioFormats && version[0] === NO_PAD_BIOFORMATS_VERSION[0]) {
-    // The version is thus 6 (there is no 7).  Check if it's version 6.2 or lower.
-    if (version[1] <= NO_PAD_BIOFORMATS_VERSION[1]) {
-      // Version 6.2 or lower with y in 6.x.y less than or equal to 1.
-      if (version[2] <= NO_PAD_BIOFORMATS_VERSION[2]) {
-        return true;
-      }
-    }
-  }
-  return false;
-}


### PR DESCRIPTION
This removes the code for handling unpadded tiles.  In general, though, we should be robust to this via #192 but for now this is a good step forward.  I'll merge once I update the docs to reflect that we should use the new `portal-containers` version for pyramid-generation but in the meantime would love the review/a checkout of the branch to make sure I didn't miss something.  Thanks!