### PR TITLE
Update sizing in overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@
 
 ### Added
 
+- Support height as primary dimension for sizing OverviewView.
+
 ### Changed
+
+- Project overview boundary sizes instead of hardcoding.
 
 ## 0.2.8
 
 ### Added
--Export constants for loader type and max channels.
+
+- Export constants for loader type and max channels.
 
 ### Changed
 

--- a/src/layers/OverviewLayer.js
+++ b/src/layers/OverviewLayer.js
@@ -43,9 +43,9 @@ const defaultProps = {
  * @param {Array} props.domain Override for the possible max/min values (i.e something different than 65535 for uint16/'<u2').
  * @param {Object} props.loader Loader to be used for fetching data.  It must implement/return `getRaster` and `dtype`.
  * @param {Array} props.boundingBoxColor [r, g, b] color of the bounding box (default: [255, 0, 0]).
- * @param {number} props.boundingBoxOutlineWidth Width of the bounding box (default: 50).
+ * @param {number} props.boundingBoxOutlineWidth Width of the bounding box in px (default: 1).
  * @param {Array} props.viewportOutlineColor [r, g, b] color of the outline (default: [255, 190, 0]).
- * @param {number} props.viewportOutlineWidth Viewport outline width (default: 400).
+ * @param {number} props.viewportOutlineWidth Viewport outline width in px (default: 2).
  */
 export default class OverviewLayer extends CompositeLayer {
   renderLayers() {

--- a/src/layers/OverviewLayer.js
+++ b/src/layers/OverviewLayer.js
@@ -25,10 +25,11 @@ const defaultProps = {
     compare: true
   },
   boundingBoxColor: { type: 'array', value: [255, 0, 0], compare: true },
-  boundingBoxOutlineWidth: { type: 'number', value: 50, compare: true },
+  boundingBoxOutlineWidth: { type: 'number', value: 1, compare: true },
   viewportOutlineColor: { type: 'array', value: [255, 190, 0], compare: true },
-  viewportOutlineWidth: { type: 'number', value: 400, compare: true },
-  overviewScale: { type: 'number', value: 1, compare: true }
+  viewportOutlineWidth: { type: 'number', value: 2, compare: true },
+  overviewScale: { type: 'number', value: 1, compare: true },
+  zoom: { type: 'number', value: 1, compare: true }
 };
 
 /**
@@ -51,6 +52,7 @@ export default class OverviewLayer extends CompositeLayer {
     const {
       loader,
       id,
+      zoom,
       boundingBox,
       boundingBoxColor,
       boundingBoxOutlineWidth,
@@ -75,7 +77,7 @@ export default class OverviewLayer extends CompositeLayer {
       filled: false,
       stroked: true,
       getLineColor: boundingBoxColor,
-      getLineWidth: boundingBoxOutlineWidth
+      getLineWidth: boundingBoxOutlineWidth * 2 ** zoom
     });
     const viewportOutline = new PolygonLayer({
       id: `viewport-outline-${id}`,
@@ -92,7 +94,7 @@ export default class OverviewLayer extends CompositeLayer {
       filled: false,
       stroked: true,
       getLineColor: viewportOutlineColor,
-      getLineWidth: viewportOutlineWidth
+      getLineWidth: viewportOutlineWidth * 2 ** zoom
     });
     const layers = [overview, boundingBoxOutline, viewportOutline];
     return layers;

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -47,7 +47,7 @@ export default class OMETiffLoader {
     // This works with the current bioformats6 pipeline.
     // Related to: https://github.com/hubmapconsortium/vitessce-image-viewer/issues/144
     this.numLevels =
-      this.omexml.getNumberOfImages() || (SubIFDs && SubIFDs.length - 1);
+      this.omexml.getNumberOfImages() || (SubIFDs && SubIFDs.length);
     this.isBioFormats6Pyramid = SubIFDs;
     this.isPyramid = this.numLevels > 1;
     // The omexml specification only allows for these - zarr is more flexible so this

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -46,8 +46,7 @@ export default class OMETiffLoader {
     // These subIFDs are going to take some tuning to get right.
     // This works with the current bioformats6 pipeline.
     // Related to: https://github.com/hubmapconsortium/vitessce-image-viewer/issues/144
-    this.numLevels =
-      this.omexml.getNumberOfImages() || (SubIFDs && SubIFDs.length);
+    this.numLevels = this.omexml.getNumberOfImages() || SubIFDs?.length;
     this.isBioFormats6Pyramid = SubIFDs;
     this.isPyramid = this.numLevels > 1;
     // The omexml specification only allows for these - zarr is more flexible so this

--- a/src/views/OverviewView.js
+++ b/src/views/OverviewView.js
@@ -15,6 +15,8 @@ import { makeBoundingBox, getVivId } from './utils';
  * @param {string} args.position Location of the viewport - one of "bottom-right", "top-right", "top-left", "bottom-left."  Default is 'bottom-right'.
  * @param {number} args.minimumWidth Absolute lower bound for how small the viewport should scale. Default is 150.
  * @param {number} args.maximumWidth Absolute upper bound for how large the viewport should scale. Default is 350.
+ * @param {number} args.minimumHeight Absolute lower bound for how small the viewport should scale. Default is 150.
+ * @param {number} args.maximumHeight Absolute upper bound for how large the viewport should scale. Default is 350.
  * */
 export default class OverviewView extends VivView {
   constructor({

--- a/src/views/OverviewView.js
+++ b/src/views/OverviewView.js
@@ -67,6 +67,8 @@ export default class OverviewView extends VivView {
     const { width: rasterWidth, height: rasterHeight } = loader.getRasterSize({
       z: 0
     });
+    this._imageWidth = rasterWidth;
+    this._imageHeight = rasterHeight;
     if (rasterWidth > rasterHeight) {
       const heightWidthRatio = rasterHeight / rasterWidth;
       this.width = Math.min(
@@ -75,8 +77,6 @@ export default class OverviewView extends VivView {
       );
       this.height = this.width * heightWidthRatio;
       this.scale = (2 ** (numLevels - 1) / rasterWidth) * this.width;
-      this._imageWidth = rasterWidth;
-      this._imageHeight = rasterHeight;
     } else {
       const widthHeightRatio = rasterWidth / rasterHeight;
       this.height = Math.min(
@@ -85,8 +85,6 @@ export default class OverviewView extends VivView {
       );
       this.width = this.height * widthHeightRatio;
       this.scale = (2 ** (numLevels - 1) / rasterHeight) * this.height;
-      this._imageWidth = rasterWidth;
-      this._imageHeight = rasterHeight;
     }
   }
 

--- a/tests/layers_views/views/OverviewView.spec.js
+++ b/tests/layers_views/views/OverviewView.spec.js
@@ -43,16 +43,49 @@ test(`OverviewView layer type check.`, t => {
   t.end();
 });
 
-test(`OverviewView respects minimumWidth and maximumWidth.`, t => {
+test(`OverviewView respects maximumHeight and minimumHeight when height > width.`, t => {
+  const minimumHeight = 350;
+  let view = new OverviewView({ ...overviewViewArguments, minimumHeight });
+  t.equal(
+    view.height,
+    350,
+    'OverviewView height should be minimumHeight when set and not calculated'
+  );
+  const maximumHeight = 5;
+  view = new OverviewView({ ...overviewViewArguments, maximumHeight });
+  t.equal(
+    view.height,
+    5,
+    'OverviewView height should be maximumHeight when set and not calculated'
+  );
+  t.end();
+});
+
+test(`OverviewView respects maximumWidth and minimumWidth when width > height.`, t => {
   const minimumWidth = 350;
-  let view = new OverviewView({ ...overviewViewArguments, minimumWidth });
+  const loaderWidth = {
+    type: 'loads',
+    numLevels: 7,
+    getRasterSize: () => {
+      return { height: 10000, width: 20000 };
+    }
+  };
+  let view = new OverviewView({
+    ...overviewViewArguments,
+    loader: loaderWidth,
+    minimumWidth
+  });
   t.equal(
     view.width,
     350,
     'OverviewView width should be minimumWidth when set and not calculated'
   );
   const maximumWidth = 5;
-  view = new OverviewView({ ...overviewViewArguments, maximumWidth });
+  view = new OverviewView({
+    ...overviewViewArguments,
+    loader: loaderWidth,
+    maximumWidth
+  });
   t.equal(
     view.width,
     5,


### PR DESCRIPTION
This fixes #198 and also resolves the weirdness that was happening in the overview for the zarr COVID-19 image since it is longer than it is wide.  I assumed that it was a result of a #198 but they turned out to be unrelated, so we now handle height > width differently than width > height in the OverviewView when calculating dimensions.

**Before**:
<img width="1670" alt="Screen Shot 2020-06-12 at 11 11 27 AM" src="https://user-images.githubusercontent.com/43999641/84517565-7c17d100-ac9d-11ea-9019-433bce825b17.png">
**After**:
<img width="1673" alt="Screen Shot 2020-06-12 at 11 08 46 AM" src="https://user-images.githubusercontent.com/43999641/84517587-820db200-ac9d-11ea-80f6-4888e480256f.png">
