### PR TITLE
RGB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support Safari in 2D raster imagery.
 - Support height as primary dimension for sizing OverviewView.
+- Add preliminary RGB check.
 
 ### Changed
 

--- a/demo/src/source-info.js
+++ b/demo/src/source-info.js
@@ -192,7 +192,7 @@ const remoteTiffRGB = {
     target: [30000, 30000]
   },
   dimensions: [
-    // This order does not matter since it is contained in the OME-XML.  
+    // This order does not matter since it is contained in the OME-XML.
     // It is just for the UI, and that should change since it can be inferred from the loader's OMEXML.
     {
       field: 'channel',

--- a/demo/src/source-info.js
+++ b/demo/src/source-info.js
@@ -178,6 +178,35 @@ const remoteBFTiff = {
 };
 
 // Generated using bioformats2raw and raw2ometiff.
+const remoteTiffRGBUrl =
+  'https://vitessce-demo-data.storage.googleapis.com/test-data/hubmap/test/VAN0008-RK-403-100-PAS_registered.ome.tif';
+
+const remoteTiffRGB = {
+  url: remoteTiffRGBUrl,
+  initialViewState: {
+    zoom: -5,
+    target: [30000, 30000]
+  },
+  dimensions: [
+    {
+      field: 'channel',
+      type: 'nominal',
+      values: ['red', 'green', 'blue']
+    },
+    { field: 'y', type: 'quantitative', values: null },
+    { field: 'x', type: 'quantitative', values: null },
+    { field: 'time', type: 'number', values: null },
+    { field: 'z', type: 'number', values: null }
+  ],
+  isPublic: false,
+  isPyramid: true,
+  selections: ['red', 'green', 'blue'].map(channel => {
+    return { channel, time: 0, z: 0 };
+  }),
+  description: 'VAN0003-LK-32-21 Donor Image'
+};
+
+// Generated using bioformats2raw and raw2ometiff.
 const remoteTiffUrl2 =
   'https://vitessce-demo-data.storage.googleapis.com/test-data/hubmap/pyramid_0.0.2/VAN0003-LK-32-21-AF_preIMS_registered.ome.tif';
 
@@ -265,5 +294,6 @@ export default {
   'bf tiff': remoteBFTiff,
   'tiff 2': remoteTiff2,
   'covid tiff': covidTiffInfo,
-  'ome-zarr': omeZarr
+  'ome-zarr': omeZarr,
+  'rgb tiff': remoteTiffRGB
 };

--- a/demo/src/source-info.js
+++ b/demo/src/source-info.js
@@ -105,6 +105,8 @@ const rootStaticTiffUrl =
 const staticTiffInfo = {
   url: rootStaticTiffUrl,
   dimensions: [
+    // This order does not matter since it is contained in the OME-XML.
+    // It is just for the UI, and that should change since it can be inferred from the loader's OMEXML.
     {
       field: 'channel',
       type: 'nominal',
@@ -157,6 +159,8 @@ const remoteBFTiff = {
     target: [5000, 5000]
   },
   dimensions: [
+    // This order does not matter since it is contained in the OME-XML.
+    // It is just for the UI, and that should change since it can be inferred from the loader's OMEXML.
     {
       field: 'channel',
       type: 'nominal',
@@ -188,6 +192,8 @@ const remoteTiffRGB = {
     target: [30000, 30000]
   },
   dimensions: [
+    // This order does not matter since it is contained in the OME-XML.  
+    // It is just for the UI, and that should change since it can be inferred from the loader's OMEXML.
     {
       field: 'channel',
       type: 'nominal',
@@ -203,7 +209,7 @@ const remoteTiffRGB = {
   selections: ['red', 'green', 'blue'].map(channel => {
     return { channel, time: 0, z: 0 };
   }),
-  description: 'VAN0003-LK-32-21 Donor Image'
+  description: 'VAN0008-RK-403-100-PAS_registered PAS Donor Image'
 };
 
 // Generated using bioformats2raw and raw2ometiff.
@@ -217,6 +223,8 @@ const remoteTiff2 = {
     target: [30000, 30000]
   },
   dimensions: [
+    // This order does not matter since it is contained in the OME-XML.
+    // It is just for the UI, and that should change since it can be inferred from the loader's OMEXML.
     {
       field: 'channel',
       type: 'nominal',
@@ -240,7 +248,7 @@ const remoteTiff2 = {
   ].map(channel => {
     return { channel, time: 0, z: 0 };
   }),
-  description: 'VAN0003-LK-32-21 Donor Image'
+  description: 'VAN0003-LK-32-21 AF Donor Image'
 };
 
 const covidTiffInfo = {

--- a/demo/src/utils.js
+++ b/demo/src/utils.js
@@ -26,6 +26,7 @@ export async function createLoader(type, infoObj) {
     case 'bf tiff':
     case 'tiff 2':
     case 'covid tiff':
+    case 'rgb tiff':
     case 'tiff': {
       const { url } = infoObj;
       const res = await fetch(url.replace(/ome.tif(f?)/gi, 'offsets.json'));

--- a/docs/OMETIFF_LOADING.md
+++ b/docs/OMETIFF_LOADING.md
@@ -48,3 +48,6 @@ gsutil -m cp -r /my/path/test-output/ gs://my/path/test-output/
 ```
 
 Note that if your tiff file is large in neither channel count nor resolution, you can simply load it in `viv` directly without passing in offsets or running this pipeline.
+
+Finally we are in the experimental stages of supporting RGB images.  Right now we only support de-interleaved images.  
+One of the biggest issues we have is lack of (what we know to be) properly formatted sample OME-TIFF data.  Please open an issue if this is important to your use-case.

--- a/docs/OMETIFF_LOADING.md
+++ b/docs/OMETIFF_LOADING.md
@@ -49,5 +49,5 @@ gsutil -m cp -r /my/path/test-output/ gs://my/path/test-output/
 
 Note that if your tiff file is large in neither channel count nor resolution, you can simply load it in `viv` directly without passing in offsets or running this pipeline.
 
-Finally we are in the experimental stages of supporting RGB images.  Right now we only support de-interleaved images.  
-One of the biggest issues we have is lack of (what we know to be) properly formatted sample OME-TIFF data.  Please open an issue if this is important to your use-case.
+Finally we are in the experimental stages of supporting RGB images. Right now we only support de-interleaved images.  
+One of the biggest issues we have is lack of (what we know to be) properly formatted sample OME-TIFF data. Please open an issue if this is important to your use-case.

--- a/src/layers/StaticImageLayer.js
+++ b/src/layers/StaticImageLayer.js
@@ -41,7 +41,7 @@ function scaleBounds({ width, height, translate, scale }) {
  * buffer, but without digging deeper into the WebGL it is a reasonable fix.
  */
 function padEven(data, width, height) {
-  const targetWidth = (width * height) % 2 === 0 ? width : width + 1;
+  const targetWidth = width % 2 === 0 ? width : width + 1;
   const padded = data.map(d =>
     padTileWithZeros({ data: d, width, height }, targetWidth, height)
   );

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -73,6 +73,9 @@ export default class OMETiffLoader {
     // We use zarr's internal format.  It encodes endiannes, but we leave it little for now
     // since javascript is little endian.
     this.dtype = DTYPE_LOOKUP[this.omexml.Type];
+    this.isRgb =
+      this.omexml.SamplesPerPixel === 3 ||
+      (this.channelNames.length === 3 && this.dtype === '<u1');
   }
 
   /**

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -70,7 +70,7 @@ export default class OMETiffLoader {
       { field: 'x', type: 'quantitative', values: null },
       { field: 'y', type: 'quantitative', values: null }
     ];
-    // We use zarr's internal format.  It encodes endiannes, but we leave it little for now
+    // We use zarr's internal format.  It encodes endianness, but we leave it little for now
     // since javascript is little endian.
     this.dtype = DTYPE_LOOKUP[this.omexml.Type];
     this.isRgb =

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -43,9 +43,6 @@ export default class OMETiffLoader {
     this.height = this.omexml.SizeY;
     this.tileSize = firstImage.getTileWidth();
     const { SubIFDs } = firstImage.fileDirectory;
-    // These subIFDs are going to take some tuning to get right.
-    // This works with the current bioformats6 pipeline.
-    // Related to: https://github.com/hubmapconsortium/vitessce-image-viewer/issues/144
     this.numLevels = this.omexml.getNumberOfImages() || SubIFDs?.length;
     this.isBioFormats6Pyramid = SubIFDs;
     this.isPyramid = this.numLevels > 1;
@@ -73,6 +70,9 @@ export default class OMETiffLoader {
     // We use zarr's internal format.  It encodes endianness, but we leave it little for now
     // since javascript is little endian.
     this.dtype = DTYPE_LOOKUP[this.omexml.Type];
+    // This is experimental and will take some tuning to properly detect.  For now,
+    // if the SamplesPerPixel is 3 (i.e interleaved) or if there are three uint8 channels,
+    // we flag that as rgb.
     this.isRgb =
       this.omexml.SamplesPerPixel === 3 ||
       (this.channelNames.length === 3 && this.dtype === '<u1');

--- a/src/loaders/omeXML.js
+++ b/src/loaders/omeXML.js
@@ -48,4 +48,11 @@ export default class OMEXML {
   getNumberOfImages() {
     return this.metadataOMEXML.Image.length || 0;
   }
+
+  get SamplesPerPixel() {
+    const { Channel } = this._Pixels;
+    return Array.isArray(Channel)
+      ? Channel.map(channel => channel['@_SamplesPerPixel'])[0]
+      : [Channel['@_SamplesPerPixel']];
+  }
 }


### PR DESCRIPTION
This is not really the PR I expected it to be, but in the interest of potentially supporting the Vanderbilt data, I think this may need to be pushed through as-is.

All we really need for Vitessce is the RGB flag itself so we display/don't display sliders.  This doesn't really mean we "support" standard interleaved RGB but for now, I think this will suffice and lay the groundwork.