### PR TITLE
Use current GL context to determine shaders/textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Use WebGL context to detect what shaders and textures to use, not whether WebGL2 is available on environment `document`.
+
 ## 0.2.11
 
 ### Added

--- a/src/constants.js
+++ b/src/constants.js
@@ -36,5 +36,3 @@ export const DTYPE_VALUES = {
     TypedArray: Float32Array
   }
 };
-
-export const NO_WEBGL2 = !document.createElement('canvas').getContext('webgl2');


### PR DESCRIPTION
Our current feature detection inspects the `document` object when importing viv, checking to see if WebGL2 is available. This is an issue for two reasons:

1.) If viv is loaded as a module outside of the browser (i.e. in a static build tool like Next.js/Gatsby that creates an bundled app with tree-shaking), the `document` doesn't exist and will throw an error. In addition, having feature detection as a global constant is in general a foot-gun. I ran into this issue because I was using viv with Next.js, and fortunately it failed loudly because the document doesn't exist. However, if we were able to feature detect in the server environment, then whatever the server detects would get sent to all clients (regardless of the browser they are using).

2.) We are checking whether WebGL2 is available in the user's browser, not whether the GL context used is WebGL2. If the context is WebGL2, the browser supports WebGL2. If the browser supports WebGL2, that doesn't mean the context is WebGL2.


The fix here is to just use luma's `isWebGL2` in the XRLayer as well:

https://github.com/visgl/luma.gl/blob/6f5d8f8b9368aa9672980ad0151e7e5a023c1ce0/modules/gltools/src/utils/webgl-checks.js#L14-L16