### PR TITLE
Fix 32 bit float error for OMEXML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix link in `IMAGE_RENDERING.md` and remove `img2zarr` reference since it has been depricated.
 - Upgrade deck.gl to 8.2.
 - Export `XRLayer`.
+- Fix OMEXML 32 bit float parse error.
 
 ## 0.2.11
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -34,7 +34,7 @@ export const DTYPE_VALUES = {
     type: GL.FLOAT,
     // Not sure what to do about this one - a good use case for channel stats, I suppose:
     // https://en.wikipedia.org/wiki/Single-precision_floating-point_format.
-    max: 3.4 * (10 ** 38),
+    max: 3.4 * 10 ** 38,
     TypedArray: Float32Array
   }
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -32,7 +32,9 @@ export const DTYPE_VALUES = {
     format: GL.R32F,
     dataFormat: GL.RED,
     type: GL.FLOAT,
-    max: 2 ** 31 - 1,
+    // Not sure what to do about this one - a good use case for channel stats, I suppose:
+    // https://en.wikipedia.org/wiki/Single-precision_floating-point_format.
+    max: 3.4 * (10 ** 38),
     TypedArray: Float32Array
   }
 };

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -230,7 +230,9 @@ export default class OMETiffLoader {
     return {
       // GeoTiff.js returns 32 bit uint when the tiff has 32 significant bits.
       data:
-        this.dtype === '<f4' ? rasters.map(r => new Float32Array(r.buffer)) : rasters,
+        this.dtype === '<f4'
+          ? rasters.map(r => new Float32Array(r.buffer))
+          : rasters,
       width,
       height
     };

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -229,7 +229,8 @@ export default class OMETiffLoader {
     const height = image.getHeight();
     return {
       // GeoTiff.js returns 32 bit uint when we the tiff has 32 significant bits.
-      data: this.dtype === '<f4' ? rasters.map(r => new Float32Array(r)): rasters,
+      data:
+        this.dtype === '<f4' ? rasters.map(r => new Float32Array(r)) : rasters,
       width,
       height
     };

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -7,7 +7,7 @@ const DTYPE_LOOKUP = {
   uint8: '<u1',
   uint16: '<u2',
   uint32: '<u4',
-  float32: '<f4'
+  float: '<f4'
 };
 
 /**
@@ -228,7 +228,8 @@ export default class OMETiffLoader {
     const width = image.getWidth();
     const height = image.getHeight();
     return {
-      data: rasters,
+      // GeoTiff.js returns 32 bit uint when we the tiff has 32 significant bits.
+      data: this.dtype === '<f4' ? rasters.map(r => new Float32Array(r)): rasters,
       width,
       height
     };

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -230,7 +230,7 @@ export default class OMETiffLoader {
     return {
       // GeoTiff.js returns 32 bit uint when the tiff has 32 significant bits.
       data:
-        this.dtype === '<f4' ? rasters.map(r => new Float32Array(r)) : rasters,
+        this.dtype === '<f4' ? rasters.map(r => new Float32Array(r.buffer)) : rasters,
       width,
       height
     };

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -228,7 +228,7 @@ export default class OMETiffLoader {
     const width = image.getWidth();
     const height = image.getHeight();
     return {
-      // GeoTiff.js returns 32 bit uint when we the tiff has 32 significant bits.
+      // GeoTiff.js returns 32 bit uint when the tiff has 32 significant bits.
       data:
         this.dtype === '<f4' ? rasters.map(r => new Float32Array(r)) : rasters,
       width,


### PR DESCRIPTION
See https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#Pixels_Type for the error (`float` not `float32`).  This is an issue with the MALDI IMS in the portal.