### PR TITLE
Do not show background layer after zoom out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Do not show background image over tiled image after zoom out.
+
 ## 0.3.1
 
 ### Added

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -110,7 +110,8 @@ export default class VivViewerLayer extends CompositeLayer {
         scale: 2 ** (numLevels - 1),
         visible:
           (-numLevels <= this.context.viewport.zoom && opacity === 1) ||
-          !viewportId || this.context.viewport.id === viewportId,
+          !viewportId ||
+          this.context.viewport.id === viewportId,
         z: numLevels - 1,
         pickable: true,
         onHover

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -109,9 +109,8 @@ export default class VivViewerLayer extends CompositeLayer {
         id: `Background-Image-${id}`,
         scale: 2 ** (numLevels - 1),
         visible:
-          opacity === 1 ||
-          (-numLevels > this.context.viewport.zoom &&
-            (!viewportId || this.context.viewport.id === viewportId)),
+          (-numLevels <= this.context.viewport.zoom && opacity === 1) ||
+          !viewportId || this.context.viewport.id === viewportId,
         z: numLevels - 1,
         pickable: true,
         onHover


### PR DESCRIPTION
Related to a comment by Nils, if you zoom out on some of the colormap images, you'll see the border disappear because the background image displays after you zoom out.  This fixes #228.