### PR TITLE
Fix PictureInPictureViewer when Low Res Tile Doesn't Bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Added
 
 ### Changed
+
 - Updated the font family for the `ScaleBarLayer`'s internal `TextLayer`.
 - Guarantee that `OverviewLayer` shows an image by forcing it to be a power of 2.
+
 ## 0.3.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 - Updated the font family for the `ScaleBarLayer`'s internal `TextLayer`.
-
+- Guarantee that `OverviewLayer` shows an image by forcing it to be a power of 2.
 ## 0.3.1
 
 ### Added

--- a/src/layers/OverviewLayer.js
+++ b/src/layers/OverviewLayer.js
@@ -64,10 +64,14 @@ export default class OverviewLayer extends CompositeLayer {
     const { width, height } = loader.getRasterSize({
       z: 0
     });
+    const { width: lowResWidth, height: lowResHeight } = loader.getRasterSize({
+      z: numLevels - 1
+    });
     const overview = new StaticImageLayer(this.props, {
       id: `viewport-${id}`,
       scale: 2 ** (numLevels - 1) * overviewScale,
-      z: numLevels - 1
+      z: numLevels - 1,
+      boxSize: 2 ** Math.ceil(Math.log2(Math.max(lowResWidth, lowResHeight))),
     });
     const boundingBoxOutline = new PolygonLayer({
       id: `bounding-box-overview-${id}`,

--- a/src/layers/OverviewLayer.js
+++ b/src/layers/OverviewLayer.js
@@ -71,7 +71,7 @@ export default class OverviewLayer extends CompositeLayer {
       id: `viewport-${id}`,
       scale: 2 ** (numLevels - 1) * overviewScale,
       z: numLevels - 1,
-      boxSize: 2 ** Math.ceil(Math.log2(Math.max(lowResWidth, lowResHeight))),
+      boxSize: 2 ** Math.ceil(Math.log2(Math.max(lowResWidth, lowResHeight)))
     });
     const boundingBoxOutline = new PolygonLayer({
       id: `bounding-box-overview-${id}`,

--- a/src/layers/OverviewLayer.js
+++ b/src/layers/OverviewLayer.js
@@ -1,6 +1,7 @@
 import { CompositeLayer, COORDINATE_SYSTEM } from '@deck.gl/core';
 import { PolygonLayer } from '@deck.gl/layers';
 import StaticImageLayer from './StaticImageLayer';
+import { getNearestPowerOf2 } from './utils';
 
 const defaultProps = {
   pickable: true,
@@ -71,7 +72,7 @@ export default class OverviewLayer extends CompositeLayer {
       id: `viewport-${id}`,
       scale: 2 ** (numLevels - 1) * overviewScale,
       z: numLevels - 1,
-      boxSize: 2 ** Math.ceil(Math.log2(Math.max(lowResWidth, lowResHeight)))
+      boxSize: getNearestPowerOf2(lowResWidth, lowResHeight)
     });
     const boundingBoxOutline = new PolygonLayer({
       id: `bounding-box-overview-${id}`,

--- a/src/layers/StaticImageLayer.js
+++ b/src/layers/StaticImageLayer.js
@@ -42,8 +42,8 @@ function scaleBounds({ width, height, translate, scale }) {
  * buffer, but without digging deeper into the WebGL it is a reasonable fix.
  */
 function padEven(data, width, height, boxSize) {
-  const targetWidth = boxSize ? boxSize : (width % 2 === 0 ? width : width + 1);
-  const targetHeight = boxSize ? boxSize : height;
+  const targetWidth = boxSize || (width % 2 === 0 ? width : width + 1);
+  const targetHeight = boxSize || height;
   const padded = data.map(d =>
     padTileWithZeros({ data: d, width, height }, targetWidth, targetHeight)
   );

--- a/src/layers/StaticImageLayer.js
+++ b/src/layers/StaticImageLayer.js
@@ -64,7 +64,7 @@ function padEven(data, width, height, boxSize) {
  * @param {number} props.scale Scaling factor for this layer to be used against the dimensions of the loader's `getRaster`.
  * @param {Object} props.loader Loader to be used for fetching data.  It must implement/return `getRaster` and `dtype`.
  * @param {String} props.onHover Hook function from deck.gl to handle hover objects.
- * @param {String} props.boxSize If you want to pad an incoming tile to be a certain squared pixel size, pass the number here (only used by OverviewLayer for now).
+ * @param {String} props.boxSize If you want to pad an incoming tile to be a certain squared pixel size, pass the number here (only used by OverviewLayer/VivViewerLayer for now).
  */
 export default class StaticImageLayer extends CompositeLayer {
   initializeState() {

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -118,7 +118,7 @@ export default class VivViewerLayer extends CompositeLayer {
         z: numLevels - 1,
         pickable: true,
         onHover,
-        boxSize: 2 ** Math.ceil(Math.log2(Math.max(lowResWidth, lowResHeight))),
+        boxSize: 2 ** Math.ceil(Math.log2(Math.max(lowResWidth, lowResHeight)))
       });
     const layers = [baseLayer, tiledLayer];
     return layers;

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -103,6 +103,9 @@ export default class VivViewerLayer extends CompositeLayer {
     // paramteter set to anything but 1, but we always use it for situations where
     // we are zoomed out too far.
     const implementsGetRaster = typeof loader.getRaster === 'function';
+    const { width: lowResWidth, height: lowResHeight } = loader.getRasterSize({
+      z: numLevels - 1
+    });
     const baseLayer =
       implementsGetRaster &&
       new StaticImageLayer(this.props, {
@@ -114,7 +117,8 @@ export default class VivViewerLayer extends CompositeLayer {
             (!viewportId || this.context.viewport.id === viewportId)),
         z: numLevels - 1,
         pickable: true,
-        onHover
+        onHover,
+        boxSize: 2 ** Math.ceil(Math.log2(Math.max(lowResWidth, lowResHeight))),
       });
     const layers = [baseLayer, tiledLayer];
     return layers;

--- a/src/layers/VivViewerLayer/VivViewerLayer.js
+++ b/src/layers/VivViewerLayer/VivViewerLayer.js
@@ -3,7 +3,7 @@ import { isWebGL2 } from '@luma.gl/core';
 
 import VivViewerLayerBase from './VivViewerLayerBase';
 import StaticImageLayer from '../StaticImageLayer';
-import { to32BitFloat } from '../utils';
+import { to32BitFloat, getNearestPowerOf2 } from '../utils';
 
 const defaultProps = {
   pickable: true,
@@ -118,7 +118,7 @@ export default class VivViewerLayer extends CompositeLayer {
         z: numLevels - 1,
         pickable: true,
         onHover,
-        boxSize: 2 ** Math.ceil(Math.log2(Math.max(lowResWidth, lowResHeight)))
+        boxSize: getNearestPowerOf2(lowResWidth, lowResHeight)
       });
     const layers = [baseLayer, tiledLayer];
     return layers;

--- a/src/layers/utils.js
+++ b/src/layers/utils.js
@@ -67,3 +67,7 @@ export function to32BitFloat(data) {
   });
   return data32bit;
 }
+
+export function getNearestPowerOf2(width, height) {
+  return 2 ** Math.ceil(Math.log2(Math.max(width, height)));
+}


### PR DESCRIPTION
There has been a resurgence of #195 that I assume is related to an issue with `bioformats2raw` that we were seeing with tile boundaries (addressed in #223).

This guarantees that the background image and the overview image are a power of 2 so that it always binds to the texture (shouldn't be necessary, and I am going to actually report this to luma.gl soon but for now this will gives us an ironclad guarantee).  This is necessary for the CCF-UI which uses picture-in-picture extensively.

cc @bherr2 