### PR TITLE
Geotiff String Data Issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: node_js
 node_js:
-  - 13
+  - 12
 cache:
   directories:
     # I think it defaults to this:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: node_js
 node_js:
-  - 10
+  - 13
 cache:
   directories:
     # I think it defaults to this:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Upgrade geotiff.js to Ilan's branch for large string fix.
+
 ## 0.3.2
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -9803,9 +9803,8 @@
       "dev": true
     },
     "geotiff": {
-      "version": "1.0.0-beta.12",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.0-beta.12.tgz",
-      "integrity": "sha512-2/hRBqpp+TLvILmvGScPFC/x8OsvbZpiZAfY10CZsHw8G+iTSauZwi5RooPGDnfymoj9CCQt3u7b3Lxrk+zUNQ==",
+      "version": "github:ilan-gold/geotiff.js#dd1f2cf5ea7242e50616b29808e8ba7d1f5dcbda",
+      "from": "github:ilan-gold/geotiff.js#ilan-gold/string_fix",
       "requires": {
         "pako": "^1.0.11",
         "threads": "^1.3.1",
@@ -18750,9 +18749,9 @@
       "dev": true
     },
     "threads": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.2.tgz",
-      "integrity": "sha512-SB3yJ3WcwGWYYsUg1Wg9IhQ88BUq1JwZlQsaBgmolSqet5wiBaFhg8cyfHFbHGRElZ/sl4bahrrSEz3Odmr1Vg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.3.tgz",
+      "integrity": "sha512-tKwFIWRgfAT85KGkrpDt2jWPO8IVH0sLNfB/pXad/VW9eUIY2Zlz+QyeizypXhPHv9IHfqRzvk2t3mPw+imhWw==",
       "requires": {
         "callsites": "^3.1.0",
         "debug": "^4.1.1",
@@ -18774,10 +18773,11 @@
       "dev": true
     },
     "through2": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-      "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
       "requires": {
+        "inherits": "^2.0.4",
         "readable-stream": "2 || 3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@luma.gl/core": "^8.2.0",
     "@luma.gl/shadertools": "^8.2.0",
     "fast-xml-parser": "^3.16.0",
-    "geotiff": "^1.0.0-beta.12",
+    "geotiff": "ilan-gold/geotiff.js#ilan-gold/string_fix",
     "quickselect": "^2.0.0",
     "zarr": "^0.3.0"
   }


### PR DESCRIPTION
This provides a temporary fix for #236.  We need to bump our `node` environment because the `TextDecoder` API apparently does not exist on 10 (12 is the same as geotiff and 13 doesn't have some gl package).